### PR TITLE
ci: add check-commits workflow for Conventional Commits lint

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -27,6 +27,6 @@ jobs:
               echo "::error::Non-conventional commit message: ${msg}"
               failed=1
             fi
-          done < <(git log --format='%s' "origin/${BASE_REF}..HEAD")
+          done < <(git log --no-merges --format='%s' "origin/${BASE_REF}..HEAD")
 
           exit ${failed}

--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -1,0 +1,32 @@
+name: Check Commits 📝
+on:
+  workflow_call:
+jobs:
+  check-commits:
+    name: Check Conventional Commits 📝
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check Conventional Commits 📝
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          : Check Conventional Commits 📝
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?: .+'
+
+          git fetch origin "${BASE_REF}"
+          failed=0
+
+          while IFS= read -r msg; do
+            [[ -z "${msg}" ]] && continue
+            if ! [[ "${msg}" =~ ${pattern} ]]; then
+              echo "::error::Non-conventional commit message: ${msg}"
+              failed=1
+            fi
+          done < <(git log --format='%s' "origin/${BASE_REF}..HEAD")
+
+          exit ${failed}

--- a/.github/workflows/pr-pull.yaml
+++ b/.github/workflows/pr-pull.yaml
@@ -19,6 +19,12 @@ jobs:
     permissions:
       contents: read
 
+  check-commits:
+    name: Check Commits 📝
+    uses: ./.github/workflows/check-commits.yaml
+    permissions:
+      contents: read
+
   build-project:
     name: Build Project 🧱
     uses: ./.github/workflows/build-project.yaml


### PR DESCRIPTION
Adds `.github/workflows/check-commits.yaml` as a reusable workflow that validates
all commit messages in a PR against the Conventional Commits spec. Wires it into
`pr-pull.yaml` so it runs alongside the format check and build on every PR.

Part of Phase 0 — item 13.
