### PR TITLE
ci: add release workflow for git-cliff changelog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release 🛫
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+permissions:
+  contents: write
+jobs:
+  changelog:
+    name: Update Changelog 📋
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Changelog with git-cliff 📋
+        id: cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit Updated Changelog 📋
+        run: |
+          : Commit Updated Changelog 📋
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changes to CHANGELOG.md"
+          else
+            git commit -m "docs: update CHANGELOG.md for ${GITHUB_REF_NAME}"
+            git push origin HEAD:main
+          fi

--- a/cliff.toml
+++ b/cliff.toml
@@ -43,7 +43,7 @@ commit_parsers = [
 
 protect_breaking_commits = true
 filter_commits = true
-tag_pattern = "v[0-9].*"
+tag_pattern = "[0-9].*"
 skip_tags = ""
 ignore_tags = ""
 topo_order = false


### PR DESCRIPTION
Adds `.github/workflows/release.yaml` which runs git-cliff on version tag pushes
to regenerate CHANGELOG.md and commit it back to main.

Also fixes cliff.toml tag_pattern from `v[0-9].*` to `[0-9].*` to match the
no-v-prefix tag convention already established in push.yaml.

Part of Phase 0 — item 14.