### PR TITLE
chore: add macOS local dev setup script and update build docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/build-aux
 !/cmake
 !/data
+!/scripts
 !/src
 !.clang-format
 !.gersemirc

--- a/README.md
+++ b/README.md
@@ -59,32 +59,51 @@ Relaunch OBS. Check **Help → Log Files → Current Log** for:
 
 ### Linux
 
+**Prerequisites:** A Debian/Ubuntu-based distribution with `sudo` access. All other
+dependencies are installed automatically by the setup script.
+
 ```bash
 git clone https://github.com/tech-noid-systems/obs-radio-output.git
 cd obs-radio-output
-sudo apt install libshout3-dev
-cmake --preset linux-x86_64
-cmake --build --preset linux-x86_64
+bash scripts/setup-dev-linux.sh
 ```
 
-Install the built plugin:
+The script detects your architecture (x86\_64 or aarch64), installs required packages, and
+runs CMake configure. Once it completes, build and install:
 
 ```bash
+cmake --build build_linux_x86_64 --config RelWithDebInfo
+
 cmake --install build_linux_x86_64 --config RelWithDebInfo \
       --prefix ~/.config/obs-studio/plugins/obs-radio-output
 ```
 
+> **Flatpak OBS:** If you installed OBS via Flatpak, the plugin path is:
+> `~/.var/app/com.obsproject.Studio/config/obs-studio/plugins/obs-radio-output`
+
 ### Windows
 
-Windows builds require Visual Studio 2022 and MSYS2. Full Windows streaming support
-(linking libshout against the MSVC build) is not yet implemented — contributions welcome.
+**Prerequisites:** Windows 10/11 x64 with Visual Studio 2022 (`Desktop development with C++`
+workload) and `winget`. MSYS2 and libshout will be installed automatically by the setup script.
 
 ```powershell
 git clone https://github.com/tech-noid-systems/obs-radio-output.git
 cd obs-radio-output
-cmake --preset windows-x64
-cmake --build --preset windows-x64
+.\scripts\Setup-Dev-Windows.ps1
 ```
+
+Once complete, build and install:
+
+```powershell
+cmake --build build_x64 --config RelWithDebInfo
+
+cmake --install build_x64 --config RelWithDebInfo `
+      --prefix "$env:APPDATA\obs-studio\plugins\obs-radio-output"
+```
+
+> **Note:** Streaming to Icecast/SHOUTcast is not yet functional on Windows. The plugin will
+> load in OBS but the streaming output requires MSVC-compatible libshout binaries (tracked as
+> a known issue — contributions welcome).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,30 +23,39 @@ Stream audio from OBS Studio directly to Icecast and SHOUTcast internet radio se
 
 ## Building from Source
 
-### Requirements
-
-- CMake 3.28 or later
-- A C compiler (Xcode on macOS, Visual Studio 2022 on Windows, GCC/Clang on Linux)
-- libshout 2.4.x
-- OBS Studio 31.x headers (fetched automatically by CMake)
-
 ### macOS
 
-```bash
+**Prerequisites:** Xcode Command Line Tools and [Homebrew](https://brew.sh). All other
+dependencies (CMake, autotools, libshout) are installed automatically by the setup script.
+
+```zsh
 git clone https://github.com/tech-noid-systems/obs-radio-output.git
 cd obs-radio-output
-cmake --preset macos
-cmake --build --preset macos
+zsh scripts/setup-dev-macos.sh
 ```
 
-### Windows
+The setup script installs dependencies, builds a Universal Binary (arm64 + x86_64) libshout,
+and runs CMake configure. Once it completes, build and install:
 
-```powershell
-git clone https://github.com/tech-noid-systems/obs-radio-output.git
-cd obs-radio-output
-cmake --preset windows-x64
-cmake --build --preset windows-x64
+```zsh
+xcodebuild -project build_macos/obs-radio-output.xcodeproj \
+           -target obs-radio-output \
+           -configuration RelWithDebInfo \
+           ONLY_ACTIVE_ARCH=NO -arch arm64 -arch x86_64
+
+cmake --install build_macos --config RelWithDebInfo \
+      --prefix release/RelWithDebInfo
+
+cp -r release/RelWithDebInfo/obs-radio-output \
+      ~/Library/Application\ Support/obs-studio/plugins/
 ```
+
+Relaunch OBS. Check **Help → Log Files → Current Log** for:
+`[obs-radio-output] plugin loaded successfully`
+
+> **Note:** The libshout build is cached in `/tmp`. If you need to rebuild it (e.g. after a
+> macOS update), delete `/tmp/libogg-universal-done` and `/tmp/libshout-universal-done` and
+> re-run the setup script.
 
 ### Linux
 
@@ -56,6 +65,25 @@ cd obs-radio-output
 sudo apt install libshout3-dev
 cmake --preset linux-x86_64
 cmake --build --preset linux-x86_64
+```
+
+Install the built plugin:
+
+```bash
+cmake --install build_linux_x86_64 --config RelWithDebInfo \
+      --prefix ~/.config/obs-studio/plugins/obs-radio-output
+```
+
+### Windows
+
+Windows builds require Visual Studio 2022 and MSYS2. Full Windows streaming support
+(linking libshout against the MSVC build) is not yet implemented — contributions welcome.
+
+```powershell
+git clone https://github.com/tech-noid-systems/obs-radio-output.git
+cd obs-radio-output
+cmake --preset windows-x64
+cmake --build --preset windows-x64
 ```
 
 ## Usage

--- a/scripts/Setup-Dev-Windows.ps1
+++ b/scripts/Setup-Dev-Windows.ps1
@@ -1,0 +1,119 @@
+# Setup-Dev-Windows.ps1 — Set up the obs-radio-output local development environment on Windows.
+#
+# What this script does:
+#   1. Checks for Visual Studio 2022 (Build Tools or IDE)
+#   2. Checks for / installs MSYS2
+#   3. Installs libshout and pkg-config via MSYS2 MinGW64
+#   4. Runs CMake configure using the 'windows-x64' preset
+#
+# Prerequisites:
+#   - Windows 10/11 x64
+#   - Run this script from the repo root in a PowerShell terminal
+#   - winget must be available (ships with Windows 11 and recent Windows 10 updates)
+#
+# After this script completes, build the plugin with:
+#   cmake --build build_x64 --config RelWithDebInfo
+#
+# Install the plugin to OBS with:
+#   cmake --install build_x64 --config RelWithDebInfo `
+#         --prefix "$env:APPDATA\obs-studio\plugins\obs-radio-output"
+#
+# NOTE: Windows streaming support (libshout linking against MSVC) is not yet
+# fully implemented. The plugin will build and load in OBS but streaming will
+# not function until MSVC-compatible libshout binaries are available.
+
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot   = Split-Path -Parent $ScriptDir
+
+function Write-Step  { param($msg) Write-Host "▶ $msg" -ForegroundColor Cyan }
+function Write-Ok    { param($msg) Write-Host "✔ $msg" -ForegroundColor Green }
+function Write-Warn  { param($msg) Write-Host "⚠ $msg" -ForegroundColor Yellow }
+function Write-Fail  { param($msg) Write-Host "✖ $msg" -ForegroundColor Red; exit 1 }
+
+# ── 1. Check Visual Studio 2022 ───────────────────────────────────────────────
+Write-Step "Checking for Visual Studio 2022..."
+
+$vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vsWhere)) {
+  Write-Warn "vswhere.exe not found. Visual Studio 2022 may not be installed."
+  Write-Host ""
+  Write-Host "Install Visual Studio 2022 (Community or Build Tools) with the" -ForegroundColor Yellow
+  Write-Host "'Desktop development with C++' workload from:" -ForegroundColor Yellow
+  Write-Host "  https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
+  Write-Host ""
+  Write-Fail "Visual Studio 2022 is required. Install it and re-run this script."
+}
+
+$vsInstall = & $vsWhere -latest -version "[17,18)" -property installationPath 2>$null
+if (-not $vsInstall) {
+  Write-Fail "Visual Studio 2022 not found. Install it with the 'Desktop development with C++' workload."
+}
+Write-Ok "Visual Studio 2022 found: $vsInstall"
+
+# ── 2. Check / install CMake ──────────────────────────────────────────────────
+Write-Step "Checking for CMake..."
+if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+  Write-Warn "CMake not found. Attempting to install via winget..."
+  if (Get-Command winget -ErrorAction SilentlyContinue) {
+    winget install --id Kitware.CMake --silent --accept-package-agreements --accept-source-agreements
+    # Refresh PATH
+    $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
+                [System.Environment]::GetEnvironmentVariable("PATH", "User")
+  } else {
+    Write-Fail "winget not available. Install CMake manually from https://cmake.org/download/"
+  }
+}
+$cmakeVersion = (cmake --version | Select-Object -First 1)
+Write-Ok "CMake found: $cmakeVersion"
+
+# ── 3. Check / install MSYS2 ─────────────────────────────────────────────────
+Write-Step "Checking for MSYS2..."
+$msys2Root = "C:\msys64"
+if (-not (Test-Path "$msys2Root\usr\bin\bash.exe")) {
+  Write-Warn "MSYS2 not found at $msys2Root. Attempting to install via winget..."
+  if (Get-Command winget -ErrorAction SilentlyContinue) {
+    winget install --id MSYS2.MSYS2 --silent --accept-package-agreements --accept-source-agreements
+    if (-not (Test-Path "$msys2Root\usr\bin\bash.exe")) {
+      Write-Fail "MSYS2 install did not produce expected files. Install manually from https://www.msys2.org/"
+    }
+  } else {
+    Write-Fail "winget not available. Install MSYS2 manually from https://www.msys2.org/ to $msys2Root"
+  }
+}
+Write-Ok "MSYS2 found at $msys2Root"
+
+# ── 4. Install libshout via MSYS2 MinGW64 ────────────────────────────────────
+Write-Step "Installing libshout and pkg-config via MSYS2 MinGW64..."
+$bash = "$msys2Root\usr\bin\bash.exe"
+& $bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-libshout mingw-w64-x86_64-pkg-config" 2>&1
+Write-Ok "MSYS2 MinGW64 libshout installed"
+
+# ── 5. CMake configure ────────────────────────────────────────────────────────
+Write-Step "Running CMake configure (preset: windows-x64)..."
+Set-Location $RepoRoot
+cmake --preset windows-x64 `
+  -DLibShout_ROOT="C:/msys64/mingw64" `
+  -DCMAKE_PREFIX_PATH="C:/msys64/mingw64"
+Write-Ok "CMake configure complete — build directory: build_x64\"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "Dev environment ready!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Build the plugin:" -ForegroundColor White
+Write-Host "  cmake --build build_x64 --config RelWithDebInfo" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Install to OBS:" -ForegroundColor White
+Write-Host "  cmake --install build_x64 --config RelWithDebInfo ``" -ForegroundColor Cyan
+Write-Host "        --prefix `"$env:APPDATA\obs-studio\plugins\obs-radio-output`"" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Then launch OBS and check Help → Log Files → Current Log for:" -ForegroundColor White
+Write-Host "  [obs-radio-output] plugin loaded successfully" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "NOTE: Streaming to Icecast/SHOUTcast is not yet functional on Windows." -ForegroundColor Yellow
+Write-Host "The plugin will load in OBS but the streaming output requires MSVC-compatible" -ForegroundColor Yellow
+Write-Host "libshout binaries (tracked as a known issue)." -ForegroundColor Yellow

--- a/scripts/setup-dev-linux.sh
+++ b/scripts/setup-dev-linux.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# setup-dev-linux.sh — Set up the obs-radio-output local development environment on Linux.
+#
+# Supports Debian/Ubuntu-based distributions.
+#
+# What this script does:
+#   1. Checks prerequisites (sudo access, apt)
+#   2. Installs required apt packages
+#   3. Runs CMake configure using the 'linux-x86_64' or 'linux-aarch64' preset
+#
+# After this script completes, build the plugin with:
+#   cmake --build build_linux_x86_64 --config RelWithDebInfo
+#
+# Install the plugin to OBS with:
+#   cmake --install build_linux_x86_64 --config RelWithDebInfo \
+#         --prefix ~/.config/obs-studio/plugins/obs-radio-output
+#
+# Then launch OBS and check Help → Log Files → Current Log for:
+#   [obs-radio-output] plugin loaded successfully
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+print_step()  { echo -e "\033[36m▶ $1\033[0m"; }
+print_ok()    { echo -e "\033[32m✔ $1\033[0m"; }
+print_warn()  { echo -e "\033[33m⚠ $1\033[0m"; }
+print_error() { echo -e "\033[31m✖ $1\033[0m" >&2; }
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+print_step "Checking prerequisites..."
+
+if ! command -v apt-get &>/dev/null; then
+  print_error "apt-get not found. This script requires a Debian/Ubuntu-based distribution."
+  exit 1
+fi
+
+if ! sudo -n true 2>/dev/null; then
+  print_warn "This script requires sudo access to install packages."
+fi
+print_ok "Prerequisites OK"
+
+# ── 2. Detect architecture ────────────────────────────────────────────────────
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64)  CMAKE_PRESET="linux-x86_64" ;;
+  aarch64) CMAKE_PRESET="linux-aarch64" ;;
+  *)
+    print_error "Unsupported architecture: ${ARCH}"
+    exit 1
+    ;;
+esac
+print_ok "Architecture: ${ARCH} — using CMake preset: ${CMAKE_PRESET}"
+
+# ── 3. Install apt packages ───────────────────────────────────────────────────
+print_step "Installing apt packages..."
+sudo apt-get update -qq
+sudo apt-get install -y \
+  build-essential \
+  ccache \
+  cmake \
+  git \
+  jq \
+  libshout3-dev \
+  ninja-build \
+  pkg-config
+print_ok "Packages installed"
+
+# ── 4. CMake configure ────────────────────────────────────────────────────────
+print_step "Running CMake configure (preset: ${CMAKE_PRESET})..."
+cd "${REPO_ROOT}"
+cmake --preset "${CMAKE_PRESET}"
+print_ok "CMake configure complete — build directory: build_${CMAKE_PRESET/linux-/linux_}/"
+
+BUILD_DIR="build_${CMAKE_PRESET/linux-/linux_}"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "\033[32mDev environment ready!\033[0m"
+echo ""
+echo "Build the plugin:"
+echo -e "  \033[36mcmake --build ${BUILD_DIR} --config RelWithDebInfo\033[0m"
+echo ""
+echo "Install to OBS:"
+echo -e "  \033[36mcmake --install ${BUILD_DIR} --config RelWithDebInfo \\\033[0m"
+echo -e "  \033[36m      --prefix ~/.config/obs-studio/plugins/obs-radio-output\033[0m"
+echo ""
+echo "Then launch OBS and check Help → Log Files → Current Log for:"
+echo -e "  \033[33m[obs-radio-output] plugin loaded successfully\033[0m"

--- a/scripts/setup-dev-macos.sh
+++ b/scripts/setup-dev-macos.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env zsh
+# setup-dev-macos.sh — Set up the obs-radio-output local development environment on macOS.
+#
+# What this script does:
+#   1. Checks prerequisites (Xcode Command Line Tools, Homebrew)
+#   2. Installs required Homebrew packages from .github/scripts/.Brewfile
+#   3. Builds a Universal Binary (arm64 + x86_64) libogg and libshout from source
+#   4. Runs CMake configure using the 'macos' preset
+#
+# After this script completes, build the plugin with:
+#   xcodebuild -project build_macos/obs-radio-output.xcodeproj \
+#              -target obs-radio-output \
+#              -configuration RelWithDebInfo \
+#              ONLY_ACTIVE_ARCH=NO \
+#              -arch arm64 -arch x86_64
+#
+# Install the plugin to OBS with:
+#   cmake --install build_macos --config RelWithDebInfo --prefix release/RelWithDebInfo
+#   # Then copy release/ contents to:
+#   # ~/Library/Application Support/obs-studio/plugins/obs-radio-output/
+
+builtin emulate -L zsh
+setopt ERR_EXIT ERR_RETURN PIPE_FAIL NO_UNSET
+
+SCRIPT_DIR=${0:A:h}
+REPO_ROOT=${SCRIPT_DIR:h}
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+print_step()  { print -P "%F{cyan}▶ $1%f" }
+print_ok()    { print -P "%F{green}✔ $1%f" }
+print_warn()  { print -P "%F{yellow}⚠ $1%f" }
+print_error() { print -P "%F{red}✖ $1%f" >&2 }
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+print_step "Checking prerequisites..."
+
+if ! xcode-select -p &>/dev/null; then
+  print_error "Xcode Command Line Tools not found."
+  print "Install them with: xcode-select --install"
+  print "Then re-run this script."
+  exit 1
+fi
+print_ok "Xcode Command Line Tools found"
+
+if ! command -v brew &>/dev/null; then
+  print_error "Homebrew not found."
+  print "Install it from https://brew.sh then re-run this script."
+  exit 1
+fi
+print_ok "Homebrew found"
+
+# ── 2. Install Homebrew dependencies ─────────────────────────────────────────
+print_step "Installing Homebrew dependencies from .Brewfile..."
+brew bundle --no-lock --file "${REPO_ROOT}/.github/scripts/.Brewfile"
+print_ok "Homebrew dependencies installed"
+
+# ── 3. Build Universal libogg ─────────────────────────────────────────────────
+if [[ -f /tmp/libogg-universal-done ]]; then
+  print_ok "Universal libogg already built (delete /tmp/libogg-universal-done to rebuild)"
+else
+  print_step "Building Universal libogg (libshout dependency)..."
+  curl -sSL https://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.gz \
+    -o /tmp/libogg.tar.gz
+  tar -xzf /tmp/libogg.tar.gz -C /tmp
+  mv /tmp/libogg-1.3.5 /tmp/libogg-src
+  pushd /tmp/libogg-src
+
+  mkdir -p build-arm64 && pushd build-arm64
+  ../configure --prefix=/tmp/libogg-arm64 \
+    CFLAGS="-arch arm64" LDFLAGS="-arch arm64"
+  make -j$(sysctl -n hw.ncpu) && make install
+  popd
+
+  mkdir -p build-x86_64 && pushd build-x86_64
+  ../configure --prefix=/tmp/libogg-x86_64 \
+    CFLAGS="-arch x86_64" LDFLAGS="-arch x86_64"
+  make -j$(sysctl -n hw.ncpu) && make install
+  popd
+
+  popd
+  touch /tmp/libogg-universal-done
+  print_ok "Universal libogg built"
+fi
+
+# ── 4. Build Universal libshout ───────────────────────────────────────────────
+if [[ -f /tmp/libshout-universal-done ]]; then
+  print_ok "Universal libshout already built (delete /tmp/libshout-universal-done to rebuild)"
+else
+  print_step "Building Universal libshout..."
+  curl -sSL https://downloads.xiph.org/releases/libshout/libshout-2.4.6.tar.gz \
+    -o /tmp/libshout.tar.gz
+  tar -xzf /tmp/libshout.tar.gz -C /tmp
+  mv /tmp/libshout-2.4.6 /tmp/icecast-libshout
+  pushd /tmp/icecast-libshout
+
+  # arm64 slice
+  mkdir -p build-arm64 && pushd build-arm64
+  PKG_CONFIG_LIBDIR=/tmp/libogg-arm64/lib/pkgconfig \
+    ../configure --prefix=/tmp/libshout-arm64 \
+      --without-openssl --without-theora --without-speex --without-opus \
+      CFLAGS="-arch arm64 -Wno-error=implicit-function-declaration" \
+      LDFLAGS="-arch arm64"
+  make -j$(sysctl -n hw.ncpu) && make install
+  popd
+
+  # x86_64 slice
+  mkdir -p build-x86_64 && pushd build-x86_64
+  PKG_CONFIG_LIBDIR=/tmp/libogg-x86_64/lib/pkgconfig \
+    ../configure --prefix=/tmp/libshout-x86_64 \
+      --without-openssl --without-theora --without-speex --without-opus \
+      CFLAGS="-arch x86_64 -Wno-error=implicit-function-declaration" \
+      LDFLAGS="-arch x86_64"
+  make -j$(sysctl -n hw.ncpu) && make install
+  popd
+
+  # Merge with lipo
+  mkdir -p /tmp/libshout-universal/lib /tmp/libshout-universal/include
+  lipo -create \
+    /tmp/libshout-arm64/lib/libshout.dylib \
+    /tmp/libshout-x86_64/lib/libshout.dylib \
+    -output /tmp/libshout-universal/lib/libshout.dylib
+  cp -r /tmp/libshout-arm64/include/shout /tmp/libshout-universal/include/
+
+  popd
+  touch /tmp/libshout-universal-done
+  print_ok "Universal libshout built"
+fi
+
+# ── 5. CMake configure ────────────────────────────────────────────────────────
+print_step "Running CMake configure (preset: macos)..."
+pushd "${REPO_ROOT}"
+cmake --preset macos -DLibShout_ROOT=/tmp/libshout-universal
+popd
+print_ok "CMake configure complete — build directory: build_macos/"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+print -P ""
+print -P "%F{green}Dev environment ready!%f"
+print -P ""
+print -P "Build the plugin:"
+print -P "  %F{cyan}xcodebuild -project build_macos/obs-radio-output.xcodeproj \\%f"
+print -P "  %F{cyan}           -target obs-radio-output \\%f"
+print -P "  %F{cyan}           -configuration RelWithDebInfo \\%f"
+print -P "  %F{cyan}           ONLY_ACTIVE_ARCH=NO -arch arm64 -arch x86_64%f"
+print -P ""
+print -P "Install to OBS:"
+print -P "  %F{cyan}cmake --install build_macos --config RelWithDebInfo \\%f"
+print -P "         %F{cyan}--prefix release/RelWithDebInfo%f"
+print -P "  %F{cyan}cp -r release/RelWithDebInfo/obs-radio-output \\%f"
+print -P "     %F{cyan}\"~/Library/Application Support/obs-studio/plugins/\"%f"
+print -P ""
+print -P "Then launch OBS and check Help → Log Files → Current Log for:"
+print -P "  %F{yellow}[obs-radio-output] plugin loaded successfully%f"


### PR DESCRIPTION
Adds scripts/setup-dev-macos.sh — a one-shot script that installs Homebrew
dependencies, builds Universal Binary libogg and libshout, and runs CMake
configure. Subsequent runs skip the library builds via /tmp sentinel files.

Updates README.md build section with accurate macOS, Linux, and Windows
instructions including plugin install paths and OBS log verification step.

Fixes .gitignore to allow the new scripts/ directory.

Addresses Phase 0 gap — local dev toolchain was never documented.