### PR TITLE
fix(scripts): correct plugin bundle path in build-and-install-macos.sh generator

### DIFF
--- a/scripts/setup-dev-macos.sh
+++ b/scripts/setup-dev-macos.sh
@@ -155,7 +155,7 @@ xcodebuild \
 
 echo "Installing to OBS plugins directory..."
 cmake --install build_macos --config RelWithDebInfo --prefix release/RelWithDebInfo
-cp -r release/RelWithDebInfo/obs-radio-output \
+cp -r "release/RelWithDebInfo/obs-radio-output.plugin" \
   "${HOME}/Library/Application Support/obs-studio/plugins/"
 
 echo ""


### PR DESCRIPTION
## Summary
- Fixes the `cp` command in the `build-and-install-macos.sh` generator inside `setup-dev-macos.sh`
- The plugin is installed as `obs-radio-output.plugin` (a macOS bundle), not a plain directory named `obs-radio-output`
- Without this fix, the generated helper script fails at the copy step after a successful build

## Test plan
- [x] Run `zsh scripts/setup-dev-macos.sh` on macOS to regenerate `build-and-install-macos.sh`
- [x] Run `zsh build-and-install-macos.sh` — verify no `cp: No such file or directory` error
- [x] Confirm plugin appears in `~/Library/Application Support/obs-studio/plugins/`
