### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,43 @@
+name: CodeQL Analysis 🔍
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze C/C++ 🔍
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Initialize CodeQL 🔍
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          queries: security-extended
+
+      - name: Build Plugin 🧱
+        uses: ./.github/actions/build-plugin
+        with:
+          target: x86_64
+          config: RelWithDebInfo
+
+      - name: Perform CodeQL Analysis 🔍
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:c-cpp"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yaml` running GitHub's CodeQL static analysis on every push to `main`, every PR targeting `main`, and on a weekly schedule (Mondays 06:00 UTC)
- Analyzes C/C++ using the `security-extended` query suite which covers CVEs, memory safety, and injection issues
- Reuses the existing `build-plugin` action for Linux x86_64 so CodeQL traces the real build with all OBS dependencies present
- Results appear in the repository's Security → Code scanning tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)