### PR TITLE
ci(quality): add clang-tidy workflow

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -23,20 +23,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Dependencies 📦
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y --no-install-recommends \
-            libshout3-dev \
-            clang-tidy
+      - name: Build Plugin 🧱
+        uses: ./.github/actions/build-plugin
+        with:
+          target: x86_64
+          config: RelWithDebInfo
 
-      - name: Generate Compile Commands 🗂️
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DENABLE_FRONTEND_API=OFF \
-            -DENABLE_QT=OFF
+      - name: Enable Compile Commands 🗂️
+        run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run Clang-Tidy 🔬
         uses: cpp-linter/cpp-linter-action@v2
@@ -62,4 +56,3 @@ jobs:
           format-review: false
           step-summary: true
           extra-args: '-std=c99'
-          tidy-tool-path: clang-tidy

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,0 +1,65 @@
+name: Clang-Tidy 🔬
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  clang-tidy:
+    name: Clang-Tidy Analysis 🔬
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install Dependencies 📦
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            libshout3-dev \
+            clang-tidy
+
+      - name: Generate Compile Commands 🗂️
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DENABLE_FRONTEND_API=OFF \
+            -DENABLE_QT=OFF
+
+      - name: Run Clang-Tidy 🔬
+        uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: ''
+          tidy-checks: >-
+            bugprone-*,
+            cert-*,
+            clang-analyzer-*,
+            misc-*,
+            performance-*,
+            portability-*,
+            readability-*,
+            -readability-magic-numbers,
+            -readability-function-cognitive-complexity
+          database: build
+          files-changed-only: true
+          thread-comments: true
+          tidy-review: true
+          format-review: false
+          step-summary: true
+          extra-args: '-std=c99'
+          tidy-tool-path: clang-tidy


### PR DESCRIPTION
## What

Adds `.github/workflows/clang-tidy.yaml` using `cpp-linter/cpp-linter-action`.

## Why

Supplements CodeQL with a fast, C-specific static analysis pass. Results surface as:
- Inline annotations on PR diffs
- A job summary in the Actions tab
- Review comments on the PR itself

## Checks
- Runs CMake configure step with `CMAKE_EXPORT_COMPILE_COMMANDS=ON` to produce a compilation database
- Analyzes only changed files on PRs (fast) — full tree on pushes to main
- Enabled check families: `bugprone-*`, `cert-*`, `clang-analyzer-*`, `misc-*`, `performance-*`, `portability-*`, `readability-*`
- Disabled: `readability-magic-numbers` (OBS settings constants), `readability-function-cognitive-complexity` (start callback is intentionally dense)