### PR TITLE
feat(icecast): implement stop and encoded_packet callbacks

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -39,16 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: ''
-          tidy-checks: >-
-            bugprone-*,
-            cert-*,
-            clang-analyzer-*,
-            misc-*,
-            performance-*,
-            portability-*,
-            readability-*,
-            -readability-magic-numbers,
-            -readability-function-cognitive-complexity
+          tidy-checks: ''
           database: build
           files-changed-only: true
           thread-comments: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # Exclude generated local dev helpers
 /build-and-install-macos.sh
 
+# Exclude clang-tidy local build directory
+/build-tidy
+
 # Exclude lock files
 *.lock.json
 

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -5,13 +5,17 @@
 #   ./scripts/run-clang-tidy.sh              # check all src/ files
 #   ./scripts/run-clang-tidy.sh src/radio-output.c   # check one file
 #
-# Requirements: brew install llvm
+# Requirements (macOS):  brew install llvm bear
+# Requirements (Linux):  apt-get install clang-tidy
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${REPO_ROOT}/build-tidy"
+COMPILE_DB="${BUILD_DIR}/compile_commands.json"
 
-# Prefer Homebrew LLVM clang-tidy over Apple's (which lacks many checks)
+# ---------------------------------------------------------------------------
+# Locate clang-tidy — prefer Homebrew LLVM over Apple's (missing many checks)
+# ---------------------------------------------------------------------------
 CLANG_TIDY=""
 for candidate in \
     "/opt/homebrew/opt/llvm/bin/clang-tidy" \
@@ -30,31 +34,67 @@ fi
 
 echo "Using: ${CLANG_TIDY}"
 echo "Version: $("${CLANG_TIDY}" --version | head -1)"
+echo ""
 
-# macOS requires the Xcode generator; Linux uses the default (Ninja/Make)
-CMAKE_EXTRA_ARGS=()
+# ---------------------------------------------------------------------------
+# Generate compile_commands.json
+#
+# macOS: Xcode generator (required by OBS) does not support
+#        CMAKE_EXPORT_COMPILE_COMMANDS.  We use 'bear' to intercept compiler
+#        calls during a real build and produce the database that way.
+#        First run is slow; subsequent runs skip the build step.
+#
+# Linux: standard cmake flag works fine with the Makefile/Ninja generator.
+# ---------------------------------------------------------------------------
 if [[ "$(uname)" == "Darwin" ]]; then
-    CMAKE_EXTRA_ARGS+=(-G Xcode)
-fi
+    if [[ ! -f "${COMPILE_DB}" ]]; then
+        if ! command -v bear &>/dev/null; then
+            echo "error: 'bear' is required for local clang-tidy on macOS." >&2
+            echo "Install it with: brew install bear" >&2
+            exit 1
+        fi
 
-# Generate/refresh compile_commands.json if needed
-if [[ ! -f "${BUILD_DIR}/compile_commands.json" ]]; then
-    echo ""
-    echo "compile_commands.json not found — running cmake configure..."
-    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
-        "${CMAKE_EXTRA_ARGS[@]}" \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        echo "compile_commands.json not found — configuring and building (first run is slow)..."
+        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Xcode
+
+        # Build with bear to capture compile commands.
+        # Signing disabled so the local build doesn't fail without a cert.
+        XCODEPROJ="$(find "${BUILD_DIR}" -maxdepth 1 -name "*.xcodeproj" | head -1)"
+        if [[ -z "${XCODEPROJ}" ]]; then
+            echo "error: no .xcodeproj found in ${BUILD_DIR}" >&2
+            exit 1
+        fi
+
+        bear --output "${COMPILE_DB}" -- \
+            xcodebuild \
+                -project "${XCODEPROJ}" \
+                -configuration RelWithDebInfo \
+                CODE_SIGN_IDENTITY="" \
+                CODE_SIGNING_REQUIRED=NO \
+                CODE_SIGNING_ALLOWED=NO \
+                -quiet
+        echo "compile_commands.json generated."
+    else
+        echo "Using existing compile_commands.json (delete build-tidy/ to rebuild)."
+    fi
 else
-    # Refresh the flag in the existing cache (fast — no re-download)
-    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
-        "${CMAKE_EXTRA_ARGS[@]}" \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
+    if [[ ! -f "${COMPILE_DB}" ]]; then
+        echo "compile_commands.json not found — running cmake configure..."
+        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    else
+        # Refresh the existing cache silently
+        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
+    fi
 fi
 
 echo ""
 
-# Determine which files to check
+# ---------------------------------------------------------------------------
+# Run clang-tidy
+# ---------------------------------------------------------------------------
 if [[ $# -gt 0 ]]; then
     FILES=("$@")
 else
@@ -64,4 +104,7 @@ fi
 echo "Checking ${#FILES[@]} file(s)..."
 echo ""
 
-"${CLANG_TIDY}" -p "${BUILD_DIR}" "${FILES[@]}"
+"${CLANG_TIDY}" \
+    -p "${BUILD_DIR}" \
+    --config-file="${REPO_ROOT}/.clang-tidy" \
+    "${FILES[@]}"

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -31,14 +31,25 @@ fi
 echo "Using: ${CLANG_TIDY}"
 echo "Version: $("${CLANG_TIDY}" --version | head -1)"
 
+# macOS requires the Xcode generator; Linux uses the default (Ninja/Make)
+CMAKE_EXTRA_ARGS=()
+if [[ "$(uname)" == "Darwin" ]]; then
+    CMAKE_EXTRA_ARGS+=(-G Xcode)
+fi
+
 # Generate/refresh compile_commands.json if needed
 if [[ ! -f "${BUILD_DIR}/compile_commands.json" ]]; then
     echo ""
     echo "compile_commands.json not found — running cmake configure..."
-    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+        "${CMAKE_EXTRA_ARGS[@]}" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
 else
     # Refresh the flag in the existing cache (fast — no re-download)
-    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+        "${CMAKE_EXTRA_ARGS[@]}" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
 fi
 
 echo ""

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# run-clang-tidy.sh — Run clang-tidy locally using the project's .clang-tidy config.
+#
+# Usage:
+#   ./scripts/run-clang-tidy.sh              # check all src/ files
+#   ./scripts/run-clang-tidy.sh src/radio-output.c   # check one file
+#
+# Requirements: brew install llvm
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+
+# Prefer Homebrew LLVM clang-tidy over Apple's (which lacks many checks)
+CLANG_TIDY=""
+for candidate in \
+    "/opt/homebrew/opt/llvm/bin/clang-tidy" \
+    "/usr/local/opt/llvm/bin/clang-tidy" \
+    "$(command -v clang-tidy 2>/dev/null || true)"; do
+    if [[ -x "${candidate}" ]]; then
+        CLANG_TIDY="${candidate}"
+        break
+    fi
+done
+
+if [[ -z "${CLANG_TIDY}" ]]; then
+    echo "error: clang-tidy not found. Install it with: brew install llvm" >&2
+    exit 1
+fi
+
+echo "Using: ${CLANG_TIDY}"
+echo "Version: $("${CLANG_TIDY}" --version | head -1)"
+
+# Generate/refresh compile_commands.json if needed
+if [[ ! -f "${BUILD_DIR}/compile_commands.json" ]]; then
+    echo ""
+    echo "compile_commands.json not found — running cmake configure..."
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+else
+    # Refresh the flag in the existing cache (fast — no re-download)
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
+fi
+
+echo ""
+
+# Determine which files to check
+if [[ $# -gt 0 ]]; then
+    FILES=("$@")
+else
+    mapfile -t FILES < <(find "${REPO_ROOT}/src" -name "*.c" -o -name "*.h")
+fi
+
+echo "Checking ${#FILES[@]} file(s)..."
+echo ""
+
+"${CLANG_TIDY}" -p "${BUILD_DIR}" "${FILES[@]}"

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # run-clang-tidy.sh — Run clang-tidy locally using the project's .clang-tidy config.
 #
-# Usage:
+# NOTE: macOS is not supported — OBS requires the Xcode CMake generator, which
+# does not produce compile_commands.json and macOS SIP prevents bear from
+# intercepting Xcode compiler calls.  Use Docker or rely on the CI check.
+#
+# Docker usage (from repo root):
+#   docker run --rm -v "$(pwd):/src" ubuntu:24.04 bash /src/scripts/run-clang-tidy.sh
+#
+# Linux usage:
 #   ./scripts/run-clang-tidy.sh              # check all src/ files
 #   ./scripts/run-clang-tidy.sh src/radio-output.c   # check one file
 #
-# Requirements (macOS):  brew install llvm bear
-# Requirements (Linux):  apt-get install clang-tidy
+# Requirements (Linux): apt-get install clang-tidy cmake libshout3-dev
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -39,55 +45,37 @@ echo ""
 # ---------------------------------------------------------------------------
 # Generate compile_commands.json
 #
-# macOS: Xcode generator (required by OBS) does not support
-#        CMAKE_EXPORT_COMPILE_COMMANDS.  We use 'bear' to intercept compiler
-#        calls during a real build and produce the database that way.
-#        First run is slow; subsequent runs skip the build step.
+# macOS: OBS requires the Xcode generator, which does not support
+#        CMAKE_EXPORT_COMPILE_COMMANDS.  macOS SIP also blocks bear from
+#        intercepting Xcode's compiler calls.  Run via Docker instead:
+#
+#   docker run --rm -v "$(pwd):/src" ubuntu:24.04 bash /src/scripts/run-clang-tidy.sh
 #
 # Linux: standard cmake flag works fine with the Makefile/Ninja generator.
 # ---------------------------------------------------------------------------
 if [[ "$(uname)" == "Darwin" ]]; then
-    if [[ ! -f "${COMPILE_DB}" ]]; then
-        if ! command -v bear &>/dev/null; then
-            echo "error: 'bear' is required for local clang-tidy on macOS." >&2
-            echo "Install it with: brew install bear" >&2
-            exit 1
-        fi
+    echo "macOS is not supported for local clang-tidy runs." >&2
+    echo "" >&2
+    echo "OBS requires the Xcode CMake generator, which does not produce" >&2
+    echo "compile_commands.json. macOS SIP also prevents bear from intercepting" >&2
+    echo "Xcode's compiler calls." >&2
+    echo "" >&2
+    echo "Use Docker to run this script on Linux instead:" >&2
+    echo "  docker run --rm -v \"\$(pwd):/src\" ubuntu:24.04 bash /src/scripts/run-clang-tidy.sh" >&2
+    echo "" >&2
+    echo "Or rely on the clang-tidy CI check which runs on every PR." >&2
+    exit 1
+fi
 
-        echo "compile_commands.json not found — configuring and building (first run is slow)..."
-        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Xcode
-
-        # Build with bear to capture compile commands.
-        # Signing disabled so the local build doesn't fail without a cert.
-        XCODEPROJ="$(find "${BUILD_DIR}" -maxdepth 1 -name "*.xcodeproj" | head -1)"
-        if [[ -z "${XCODEPROJ}" ]]; then
-            echo "error: no .xcodeproj found in ${BUILD_DIR}" >&2
-            exit 1
-        fi
-
-        bear --output "${COMPILE_DB}" -- \
-            xcodebuild \
-                -project "${XCODEPROJ}" \
-                -configuration RelWithDebInfo \
-                CODE_SIGN_IDENTITY="" \
-                CODE_SIGNING_REQUIRED=NO \
-                CODE_SIGNING_ALLOWED=NO \
-                -quiet
-        echo "compile_commands.json generated."
-    else
-        echo "Using existing compile_commands.json (delete build-tidy/ to rebuild)."
-    fi
+if [[ ! -f "${COMPILE_DB}" ]]; then
+    echo "compile_commands.json not found — running cmake configure..."
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
 else
-    if [[ ! -f "${COMPILE_DB}" ]]; then
-        echo "compile_commands.json not found — running cmake configure..."
-        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    else
-        # Refresh the existing cache silently
-        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
-    fi
+    # Refresh the existing cache silently
+    cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON > /dev/null 2>&1
 fi
 
 echo ""

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BUILD_DIR="${REPO_ROOT}/build"
+BUILD_DIR="${REPO_ROOT}/build-tidy"
 
 # Prefer Homebrew LLVM clang-tidy over Apple's (which lacks many checks)
 CLANG_TIDY=""

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -144,14 +144,43 @@ static bool radio_output_start(void *data)
 
 static void radio_output_stop(void *data, uint64_t ts)
 {
-	UNUSED_PARAMETER(data);
 	UNUSED_PARAMETER(ts);
+	struct radio_output *context = data;
+
+#ifdef HAVE_LIBSHOUT
+	if (context->shout) {
+		shout_close(context->shout);
+		shout_free(context->shout);
+		context->shout = NULL;
+	}
+#endif
+
+	set_state(context, RADIO_STATE_DISCONNECTED);
+	obs_log(LOG_INFO, "Disconnected from %s:%d%s", context->host, context->port, context->mount);
+	obs_output_end_data_capture(context->output);
 }
 
 static void radio_output_encoded_packet(void *data, struct encoder_packet *packet)
 {
+#ifndef HAVE_LIBSHOUT
 	UNUSED_PARAMETER(data);
 	UNUSED_PARAMETER(packet);
+#else
+	struct radio_output *context = data;
+
+	if (!context->shout)
+		return;
+
+	int ret = shout_send(context->shout, (const unsigned char *)packet->data, (size_t)packet->size);
+	if (ret != SHOUTERR_SUCCESS) {
+		obs_log(LOG_ERROR, "shout_send() failed: %s", shout_get_error(context->shout));
+		set_state(context, RADIO_STATE_ERROR);
+		obs_output_signal_stop(context->output, OBS_OUTPUT_DISCONNECTED);
+		return;
+	}
+
+	shout_sync(context->shout);
+#endif
 }
 
 static obs_properties_t *radio_output_get_properties(void *data)

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -171,7 +171,7 @@ static void radio_output_encoded_packet(void *data, struct encoder_packet *packe
 	if (!context->shout)
 		return;
 
-	int ret = shout_send(context->shout, (const unsigned char *)packet->data, (size_t)packet->size);
+	int ret = shout_send(context->shout, (const unsigned char *)packet->data, packet->size);
 	if (ret != SHOUTERR_SUCCESS) {
 		obs_log(LOG_ERROR, "shout_send() failed: %s", shout_get_error(context->shout));
 		set_state(context, RADIO_STATE_ERROR);


### PR DESCRIPTION
## What

Implements the two remaining stub callbacks in `radio-output.c`.

### `radio_output_stop`
- Closes and frees the libshout connection
- Sets state to `RADIO_STATE_DISCONNECTED`
- Calls `obs_output_end_data_capture` to signal OBS the stream has ended

### `radio_output_encoded_packet`
- Sends each encoded audio buffer to the Icecast/SHOUTcast server via `shout_send`
- Calls `shout_sync` for libshout's built-in bitrate pacing
- On send failure: sets `RADIO_STATE_ERROR` and signals `OBS_OUTPUT_DISCONNECTED` (reconnect logic comes in a future phase)

Both functions are guarded by `HAVE_LIBSHOUT` so Windows CI builds cleanly.

## Test plan
Manual verification after merge — rebuild and test a live stream against a local Icecast instance.