### PR TITLE
feat(reconnect): auto-reconnect thread with configurable delay and retry limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ if(ENABLE_QT)
   )
 endif()
 
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.c src/radio-output.c src/radio-output.h)
+target_sources(
+  ${CMAKE_PROJECT_NAME}
+  PRIVATE src/plugin-main.c src/radio-output.c src/radio-output.h src/reconnect.c src/reconnect.h
+)
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "radio-output.h"
+#include "reconnect.h"
 #include <plugin-support.h>
 
 static const char *radio_output_get_name(void *type_data)
@@ -50,6 +51,8 @@ static void radio_output_destroy(void *data)
 	if (!context)
 		return;
 
+	reconnect_cancel(context);
+
 #ifdef HAVE_LIBSHOUT
 	if (context->shout) {
 		shout_close(context->shout);
@@ -63,13 +66,6 @@ static void radio_output_destroy(void *data)
 	bfree(context->mount);
 	bfree(context->password);
 	bfree(context);
-}
-
-static inline void set_state(struct radio_output *context, radio_state_t state)
-{
-	pthread_mutex_lock(&context->state_mutex);
-	context->state = state;
-	pthread_mutex_unlock(&context->state_mutex);
 }
 
 static bool radio_output_start(void *data)
@@ -147,6 +143,9 @@ static void radio_output_stop(void *data, uint64_t ts)
 	UNUSED_PARAMETER(ts);
 	struct radio_output *context = data;
 
+	/* Cancel any in-progress reconnect before touching the shout handle. */
+	reconnect_cancel(context);
+
 #ifdef HAVE_LIBSHOUT
 	if (context->shout) {
 		shout_close(context->shout);
@@ -174,8 +173,24 @@ static void radio_output_encoded_packet(void *data, struct encoder_packet *packe
 	int ret = shout_send(context->shout, (const unsigned char *)packet->data, packet->size);
 	if (ret != SHOUTERR_SUCCESS) {
 		obs_log(LOG_ERROR, "shout_send() failed: %s", shout_get_error(context->shout));
-		set_state(context, RADIO_STATE_ERROR);
-		obs_output_signal_stop(context->output, OBS_OUTPUT_DISCONNECTED);
+
+		/* Close the dead connection before attempting to reconnect. */
+		shout_close(context->shout);
+		shout_free(context->shout);
+		context->shout = NULL;
+
+		if (context->reconnect_enabled) {
+			/*
+			 * reconnect_start sets state to RECONNECTING and spawns
+			 * the background thread.  Encoded packets will be silently
+			 * dropped (shout == NULL guard above) until the thread
+			 * restores the connection.
+			 */
+			reconnect_start(context);
+		} else {
+			set_state(context, RADIO_STATE_ERROR);
+			obs_output_signal_stop(context->output, OBS_OUTPUT_DISCONNECTED);
+		}
 		return;
 	}
 

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -50,7 +50,7 @@ struct radio_output {
 
 	// Reconnect thread
 	pthread_t reconnect_thread;
-	bool reconnect_active;          // true = thread was spawned and must be joined
+	bool reconnect_active;           // true = thread was spawned and must be joined
 	volatile bool reconnect_running; // false = signal thread to stop
 };
 

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -42,19 +42,29 @@ struct radio_output {
 	radio_state_t state;
 	pthread_mutex_t state_mutex;
 
-	// Reconnect
+	// Reconnect settings
 	bool reconnect_enabled;
 	int reconnect_delay_ms;
 	int reconnect_max_retries;
 	int reconnect_attempts;
+
+	// Reconnect thread
 	pthread_t reconnect_thread;
-	bool reconnect_thread_running;
+	bool reconnect_active;          // true = thread was spawned and must be joined
+	volatile bool reconnect_running; // false = signal thread to stop
 };
 
 // Codec identifiers
 #define RADIO_CODEC_OPUS   0
 #define RADIO_CODEC_MP3    1
 #define RADIO_CODEC_VORBIS 2 // Phase 2
+
+static inline void set_state(struct radio_output *context, radio_state_t new_state)
+{
+	pthread_mutex_lock(&context->state_mutex);
+	context->state = new_state;
+	pthread_mutex_unlock(&context->state_mutex);
+}
 
 // Settings key names (used in obs_data_get_* calls)
 #define SETTING_HOST            "host"

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -84,15 +84,14 @@ static void *reconnect_thread_fn(void *data)
 			break;
 
 		context->reconnect_attempts++;
-		obs_log(LOG_INFO, "[reconnect] attempt %d/%d to %s:%d%s ...",
-		        context->reconnect_attempts, context->reconnect_max_retries,
-		        context->host, context->port, context->mount);
+		obs_log(LOG_INFO, "[reconnect] attempt %d/%d to %s:%d%s ...", context->reconnect_attempts,
+			context->reconnect_max_retries, context->host, context->port, context->mount);
 
 		if (attempt_connect(context)) {
 			set_state(context, RADIO_STATE_CONNECTED);
 			context->reconnect_attempts = 0;
-			obs_log(LOG_INFO, "[reconnect] reconnected to %s:%d%s",
-			        context->host, context->port, context->mount);
+			obs_log(LOG_INFO, "[reconnect] reconnected to %s:%d%s", context->host, context->port,
+				context->mount);
 			return NULL;
 		}
 
@@ -100,7 +99,7 @@ static void *reconnect_thread_fn(void *data)
 		if (context->reconnect_max_retries > 0 &&
 		    context->reconnect_attempts >= context->reconnect_max_retries) {
 			obs_log(LOG_ERROR, "[reconnect] max retries (%d) exceeded — giving up",
-			        context->reconnect_max_retries);
+				context->reconnect_max_retries);
 			set_state(context, RADIO_STATE_ERROR);
 			obs_output_signal_stop(context->output, OBS_OUTPUT_ERROR);
 			return NULL;
@@ -148,7 +147,7 @@ void reconnect_start(struct radio_output *context)
 
 	context->reconnect_active = true;
 	obs_log(LOG_INFO, "[reconnect] reconnect thread started (delay %d ms, max %d retries)",
-	        context->reconnect_delay_ms, context->reconnect_max_retries);
+		context->reconnect_delay_ms, context->reconnect_max_retries);
 #endif
 }
 

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "reconnect.h"
+
+#include <plugin-support.h>
+#include <util/platform.h>
+
+/* -------------------------------------------------------------------------
+ * Internal helpers (libshout builds only)
+ * ---------------------------------------------------------------------- */
+
+#ifdef HAVE_LIBSHOUT
+
+/**
+ * attempt_connect - Create a fresh libshout handle and open a connection.
+ *
+ * On success context->shout is set to the live handle and true is returned.
+ * On failure the handle is freed and false is returned; context->shout is
+ * not modified.
+ */
+static bool attempt_connect(struct radio_output *context)
+{
+	shout_t *shout = shout_new();
+	if (!shout) {
+		obs_log(LOG_ERROR, "[reconnect] shout_new() failed — out of memory?");
+		return false;
+	}
+
+	char agent[64];
+	snprintf(agent, sizeof(agent), "obs-radio-output/%s", PLUGIN_VERSION);
+
+	unsigned int fmt = (context->codec == RADIO_CODEC_MP3) ? SHOUT_FORMAT_MP3 : SHOUT_FORMAT_OGG;
+
+	shout_set_host(shout, context->host);
+	shout_set_port(shout, (unsigned short)context->port);
+	shout_set_mount(shout, context->mount);
+	shout_set_password(shout, context->password);
+	shout_set_agent(shout, agent);
+	shout_set_protocol(shout, SHOUT_PROTOCOL_HTTP);
+	shout_set_content_format(shout, fmt, 0, NULL);
+
+	int err = shout_open(shout);
+	if (err != SHOUTERR_SUCCESS) {
+		obs_log(LOG_WARNING, "[reconnect] shout_open() failed: %s", shout_get_error(shout));
+		shout_free(shout);
+		return false;
+	}
+
+	context->shout = shout;
+	return true;
+}
+
+/**
+ * reconnect_thread_fn - Background thread that retries the Icecast connection.
+ *
+ * Loop:
+ *   1. Sleep reconnect_delay_ms in 100 ms chunks, checking reconnect_running
+ *      between each chunk so the thread can be cancelled promptly.
+ *   2. Call attempt_connect().
+ *   3a. Success → set state CONNECTED, log, return.
+ *   3b. Failure and max retries reached → signal OBS_OUTPUT_ERROR, return.
+ *   3c. Failure and retries remain → loop back to step 1.
+ *
+ * context->shout must be NULL when this thread starts.  On success the thread
+ * sets context->shout to the live handle; encoded_packet will pick it up on the
+ * next call.
+ */
+static void *reconnect_thread_fn(void *data)
+{
+	struct radio_output *context = data;
+
+	while (context->reconnect_running) {
+		/* Interruptible sleep — wake every 100 ms to check the stop flag. */
+		int elapsed = 0;
+		while (elapsed < context->reconnect_delay_ms && context->reconnect_running) {
+			int chunk = context->reconnect_delay_ms - elapsed;
+			if (chunk > 100)
+				chunk = 100;
+			os_sleep_ms((uint32_t)chunk);
+			elapsed += chunk;
+		}
+
+		if (!context->reconnect_running)
+			break;
+
+		context->reconnect_attempts++;
+		obs_log(LOG_INFO, "[reconnect] attempt %d/%d to %s:%d%s ...",
+		        context->reconnect_attempts, context->reconnect_max_retries,
+		        context->host, context->port, context->mount);
+
+		if (attempt_connect(context)) {
+			set_state(context, RADIO_STATE_CONNECTED);
+			context->reconnect_attempts = 0;
+			obs_log(LOG_INFO, "[reconnect] reconnected to %s:%d%s",
+			        context->host, context->port, context->mount);
+			return NULL;
+		}
+
+		/* Check retry limit (0 = unlimited). */
+		if (context->reconnect_max_retries > 0 &&
+		    context->reconnect_attempts >= context->reconnect_max_retries) {
+			obs_log(LOG_ERROR, "[reconnect] max retries (%d) exceeded — giving up",
+			        context->reconnect_max_retries);
+			set_state(context, RADIO_STATE_ERROR);
+			obs_output_signal_stop(context->output, OBS_OUTPUT_ERROR);
+			return NULL;
+		}
+	}
+
+	return NULL;
+}
+
+#endif /* HAVE_LIBSHOUT */
+
+/* -------------------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------------- */
+
+void reconnect_start(struct radio_output *context)
+{
+#ifndef HAVE_LIBSHOUT
+	UNUSED_PARAMETER(context);
+#else
+	if (!context->reconnect_enabled)
+		return;
+
+	/*
+	 * Join any thread that finished on its own (e.g. a prior reconnect that
+	 * succeeded, or one that hit max retries).  This prevents a thread leak
+	 * if encoded_packet calls reconnect_start a second time.
+	 */
+	if (context->reconnect_active) {
+		context->reconnect_running = false;
+		pthread_join(context->reconnect_thread, NULL);
+		context->reconnect_active = false;
+	}
+
+	set_state(context, RADIO_STATE_RECONNECTING);
+	context->reconnect_running = true;
+
+	if (pthread_create(&context->reconnect_thread, NULL, reconnect_thread_fn, context) != 0) {
+		obs_log(LOG_ERROR, "[reconnect] pthread_create() failed");
+		context->reconnect_running = false;
+		set_state(context, RADIO_STATE_ERROR);
+		obs_output_signal_stop(context->output, OBS_OUTPUT_ERROR);
+		return;
+	}
+
+	context->reconnect_active = true;
+	obs_log(LOG_INFO, "[reconnect] reconnect thread started (delay %d ms, max %d retries)",
+	        context->reconnect_delay_ms, context->reconnect_max_retries);
+#endif
+}
+
+void reconnect_cancel(struct radio_output *context)
+{
+#ifndef HAVE_LIBSHOUT
+	UNUSED_PARAMETER(context);
+#else
+	if (!context->reconnect_active)
+		return;
+
+	context->reconnect_running = false;
+	pthread_join(context->reconnect_thread, NULL);
+	context->reconnect_active = false;
+	obs_log(LOG_INFO, "[reconnect] reconnect thread stopped");
+#endif
+}

--- a/src/reconnect.h
+++ b/src/reconnect.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include "radio-output.h"
+
+/**
+ * reconnect_start - Spawn the reconnect background thread.
+ *
+ * Call this when a send failure is detected inside encoded_packet (i.e. after
+ * context->shout has been closed and set to NULL).  If reconnect_enabled is
+ * false the call is a no-op.  If a previous reconnect thread is still alive it
+ * is joined first.
+ */
+void reconnect_start(struct radio_output *context);
+
+/**
+ * reconnect_cancel - Stop and join the reconnect thread.
+ *
+ * Safe to call when no thread is running.  Always call this before closing the
+ * shout handle in radio_output_stop / radio_output_destroy so the thread
+ * cannot write to a freed handle.
+ */
+void reconnect_cancel(struct radio_output *context);


### PR DESCRIPTION
Implements item 16 — the auto-reconnect background module.

## Changes

- `src/radio-output.h` — promotes `set_state` to a shared `static inline` so both translation units can use it without duplication
- `src/reconnect.h` — public API: `reconnect_start` / `reconnect_cancel`
- `src/reconnect.c` — background pthread loop; sleeps in 100 ms chunks (interruptible), retries `shout_open` on a fresh handle each attempt, signals `OBS_OUTPUT_ERROR` on max-retries-exceeded; `reconnect_max_retries = 0` means unlimited
- `src/radio-output.c` — `encoded_packet` closes the dead shout handle and calls `reconnect_start` on failure; packets are silently dropped while `shout == NULL`; `radio_output_stop` and `radio_output_destroy` both call `reconnect_cancel` before touching the shout handle to prevent the thread writing to a freed pointer
- `CMakeLists.txt` — adds `reconnect.c` / `reconnect.h` to `target_sources`

## Implementation notes

Thread lifecycle uses the two-flag pattern from `radio-output.h`: `reconnect_active` tracks whether a thread was spawned and must be joined; `volatile reconnect_running` is the stop signal the thread reads between sleep chunks.