### PR TITLE
fix(reconnect): apply SHOUT_USAGE_AUDIO and audio_info on reconnect

### DIFF
--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -91,6 +91,44 @@ static void radio_output_destroy(void *data)
 	bfree(context);
 }
 
+#ifdef HAVE_LIBSHOUT
+void shout_apply_settings(struct radio_output *context, shout_t *shout)
+{
+	char agent[64];
+	snprintf(agent, sizeof(agent), "obs-radio-output/%s", PLUGIN_VERSION);
+
+	unsigned int fmt = (context->codec == RADIO_CODEC_MP3) ? SHOUT_FORMAT_MP3 : SHOUT_FORMAT_OGG;
+
+	shout_set_host(shout, context->host);
+	shout_set_port(shout, (unsigned short)context->port);
+	shout_set_mount(shout, context->mount);
+	shout_set_password(shout, context->password);
+	shout_set_agent(shout, agent);
+	shout_set_protocol(shout, SHOUT_PROTOCOL_HTTP);
+
+	/* libshout 2.4.6: shout_set_content_format() only maps SHOUT_FORMAT_MP3
+	 * to "audio/mpeg" when usage == SHOUT_USAGE_AUDIO.  Without it the
+	 * function falls through to OGG, causing Icecast to run its OGG parser
+	 * on the raw MP3 stream and silently drop the source. */
+	shout_set_content_format(shout, fmt, SHOUT_USAGE_AUDIO, NULL);
+
+	/* Audio info: shout_sync() uses the bitrate to pace sends; without it
+	 * audiorate = 0 and shout_sync can sleep indefinitely.  Also populates
+	 * the audio_info stats on the Icecast admin page. */
+	char ai_bitrate[16], ai_samplerate[16];
+	uint32_t sample_rate = 48000;
+#ifdef HAVE_LAME
+	if (context->lame_gfp)
+		sample_rate = (uint32_t)lame_get_in_samplerate(context->lame_gfp);
+#endif
+	snprintf(ai_bitrate, sizeof(ai_bitrate), "%d", context->bitrate);
+	snprintf(ai_samplerate, sizeof(ai_samplerate), "%u", sample_rate);
+	shout_set_audio_info(shout, SHOUT_AI_BITRATE, ai_bitrate);
+	shout_set_audio_info(shout, SHOUT_AI_SAMPLERATE, ai_samplerate);
+	shout_set_audio_info(shout, SHOUT_AI_CHANNELS, "2");
+}
+#endif
+
 #ifdef HAVE_LAME
 /*
  * mp3_send_thread — dequeues encoded MP3 frames from the ring buffer and
@@ -211,35 +249,7 @@ static bool radio_output_start(void *data)
 		return false;
 	}
 
-	char agent[64];
-	snprintf(agent, sizeof(agent), "obs-radio-output/%s", PLUGIN_VERSION);
-
-	shout_set_host(context->shout, context->host);
-	shout_set_port(context->shout, context->port);
-	shout_set_mount(context->shout, context->mount);
-	shout_set_password(context->shout, context->password);
-	shout_set_agent(context->shout, agent);
-	shout_set_protocol(context->shout, SHOUT_PROTOCOL_HTTP);
-
-	/* libshout 2.4.6: shout_set_content_format() only maps SHOUT_FORMAT_MP3
-	 * to "audio/mpeg" when usage == SHOUT_USAGE_AUDIO (0x0001).  Without
-	 * it the function falls through to OGG, causing Icecast to run its
-	 * OGG parser on the raw MP3 stream and silently drop all source data. */
-	unsigned int shout_format = (context->codec == RADIO_CODEC_MP3) ? SHOUT_FORMAT_MP3 : SHOUT_FORMAT_OGG;
-	shout_set_content_format(context->shout, shout_format, SHOUT_USAGE_AUDIO, NULL);
-
-	/* Audio info — libshout's shout_sync() uses the bitrate to calculate
-	 * how long to sleep between sends.  Without it, audiorate = 0 and
-	 * shout_sync can sleep indefinitely. */
-	{
-		char ai_bitrate[16], ai_samplerate[16];
-		snprintf(ai_bitrate, sizeof(ai_bitrate), "%d", context->bitrate);
-		snprintf(ai_samplerate, sizeof(ai_samplerate), "%u",
-			 (context->lame_gfp ? (unsigned)lame_get_in_samplerate(context->lame_gfp) : 48000));
-		shout_set_audio_info(context->shout, SHOUT_AI_BITRATE, ai_bitrate);
-		shout_set_audio_info(context->shout, SHOUT_AI_SAMPLERATE, ai_samplerate);
-		shout_set_audio_info(context->shout, SHOUT_AI_CHANNELS, "2");
-	}
+	shout_apply_settings(context, context->shout);
 
 	/* --- Open connection --- */
 	set_state(context, RADIO_STATE_CONNECTING);

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -84,6 +84,19 @@ static inline void set_state(struct radio_output *context, radio_state_t new_sta
 	pthread_mutex_unlock(&context->state_mutex);
 }
 
+#ifdef HAVE_LIBSHOUT
+/**
+ * shout_apply_settings - Configure a fresh shout_t handle with the plugin's
+ * Icecast settings (host, port, mount, password, agent, protocol, content
+ * format, audio info).
+ *
+ * Used by both the initial connect (radio_output_start) and the reconnect
+ * path (reconnect.c) so the two cannot drift.  Caller owns shout_new() and
+ * shout_open().
+ */
+void shout_apply_settings(struct radio_output *context, shout_t *shout);
+#endif
+
 // Settings key names (used in obs_data_get_* calls)
 #define SETTING_HOST            "host"
 #define SETTING_PORT            "port"

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -51,8 +51,8 @@ static bool attempt_connect(struct radio_output *context)
  *   3c. Failure and retries remain → loop back to step 1.
  *
  * context->shout must be NULL when this thread starts.  On success the thread
- * sets context->shout to the live handle; encoded_packet will pick it up on the
- * next call.
+ * sets context->shout to the live handle; the MP3 sender thread will pick it
+ * up on its next loop iteration.
  */
 static void *reconnect_thread_fn(void *data)
 {
@@ -115,7 +115,7 @@ void reconnect_start(struct radio_output *context)
 	/*
 	 * Join any thread that finished on its own (e.g. a prior reconnect that
 	 * succeeded, or one that hit max retries).  This prevents a thread leak
-	 * if encoded_packet calls reconnect_start a second time.
+	 * if the MP3 sender thread calls reconnect_start a second time.
 	 */
 	if (context->reconnect_active) {
 		context->reconnect_running = false;

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -26,18 +26,7 @@ static bool attempt_connect(struct radio_output *context)
 		return false;
 	}
 
-	char agent[64];
-	snprintf(agent, sizeof(agent), "obs-radio-output/%s", PLUGIN_VERSION);
-
-	unsigned int fmt = (context->codec == RADIO_CODEC_MP3) ? SHOUT_FORMAT_MP3 : SHOUT_FORMAT_OGG;
-
-	shout_set_host(shout, context->host);
-	shout_set_port(shout, (unsigned short)context->port);
-	shout_set_mount(shout, context->mount);
-	shout_set_password(shout, context->password);
-	shout_set_agent(shout, agent);
-	shout_set_protocol(shout, SHOUT_PROTOCOL_HTTP);
-	shout_set_content_format(shout, fmt, 0, NULL);
+	shout_apply_settings(context, shout);
 
 	int err = shout_open(shout);
 	if (err != SHOUTERR_SUCCESS) {

--- a/src/reconnect.h
+++ b/src/reconnect.h
@@ -6,7 +6,7 @@
 /**
  * reconnect_start - Spawn the reconnect background thread.
  *
- * Call this when a send failure is detected inside encoded_packet (i.e. after
+ * Call this when the MP3 sender thread detects a send failure (after
  * context->shout has been closed and set to NULL).  If reconnect_enabled is
  * false the call is a no-op.  If a previous reconnect thread is still alive it
  * is joined first.


### PR DESCRIPTION
**Summary**
- Reconnect was silently broken after PR #18's raw-audio pivot: `attempt_connect` in `reconnect.c` passed `usage=0` to `shout_set_content_format` (libshout 2.4.6 falls through to `application/ogg` when usage != `SHOUT_USAGE_AUDIO`, so Icecast runs its OGG parser on MP3 bytes and silently drops the source) and also omitted `shout_set_audio_info` calls so `shout_sync()` had `audiorate=0` and couldn't pace sends.
- Extract the shared `shout_t` setup into a `shout_apply_settings()` helper used by both `radio_output_start` and `reconnect.c::attempt_connect` so the two paths cannot drift again — the root cause of this bug was inline-duplicated-then-forgotten setup.
- Remove stale `encoded_packet` references in `reconnect.h` / `reconnect.c` comments (dead reference after PR #18 switched from `OBS_OUTPUT_ENCODED` to raw-audio capture).

**Test plan**
- CI passes (clang-format, CMake format, build × all platforms)
- Local reconnect drill on macOS confirms fix:
  - Start stream, verify Icecast admin shows `sources: 1`, `server_type: audio/mpeg`, VLC plays cleanly
  - `docker stop icecast-dev` → socket error detected, reconnect thread spawns
  - 2–3 reconnect attempts fail while server is down (expected)
  - `docker start icecast-dev` → next attempt succeeds: `[reconnect] reconnected to localhost:8000/stream`
  - **Post-reconnect Icecast admin now shows `sources: 1` with `server_type: audio/mpeg`** (previously `sources: 0` due to format drift — the bug)
  - `total_bytes_read` climbs steadily, VLC plays cleanly after reopening the stream URL
  - Clean stop — send thread joined before shout close, no crashes