### PR TITLE
fix(stop): make radio_output_stop idempotent to dedupe disconnect log

### DIFF
--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -339,6 +339,16 @@ static void radio_output_stop(void *data, uint64_t ts)
 	UNUSED_PARAMETER(ts);
 	struct radio_output *context = data;
 
+	/* OBS may re-enter this callback (e.g. obs_output_release on an active
+	 * output).  Bail out if we've already torn down so the disconnect log
+	 * and end_data_capture fire exactly once. */
+	pthread_mutex_lock(&context->state_mutex);
+	if (context->state == RADIO_STATE_DISCONNECTED) {
+		pthread_mutex_unlock(&context->state_mutex);
+		return;
+	}
+	pthread_mutex_unlock(&context->state_mutex);
+
 	/* Cancel any in-progress reconnect before touching the shout handle. */
 	reconnect_cancel(context);
 


### PR DESCRIPTION
**Summary**
- Guard `radio_output_stop` on `state == RADIO_STATE_DISCONNECTED` so it bails out on re-entry. OBS calls the stop callback a second time on `obs_output_release` of an active output (reproducible via `scripts/radio-test.lua`), which caused the `Disconnected from …` log and `obs_output_end_data_capture` to fire twice on every stop.
- Cosmetic fix only — no functional change. First call runs the full teardown; the state is set to `DISCONNECTED` at the end (unchanged), so the second call trips the new guard immediately.
- ERROR → Stop path is unaffected: state is `ERROR` on entry, guard passes through, cleanup runs as before.

**Test plan**
- CI passes (clang-format, CMake format, build)
- Manual acceptance re-run: start output, stop output — `Disconnected from localhost:8000/stream` appears exactly once in the OBS log
- ERROR path: force max-retries-exceeded, click Stop — cleanup still runs and disconnect log still fires exactly once