### PR TITLE
fix: error-state teardown — bypassed stop callback + TCP timeout + UAF

### DIFF
--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -52,7 +52,9 @@ static void radio_output_destroy(void *data)
 	if (!context)
 		return;
 
+	obs_log(LOG_INFO, "destroy: DBG-D0 callback entered");
 	reconnect_cancel(context);
+	obs_log(LOG_INFO, "destroy: DBG-D1 after reconnect_cancel");
 
 #ifdef HAVE_LAME
 	/* Guard against destroy being called without stop (e.g. Lua GC). */
@@ -370,6 +372,8 @@ static void radio_output_stop(void *data, uint64_t ts)
 {
 	UNUSED_PARAMETER(ts);
 	struct radio_output *context = data;
+
+	obs_log(LOG_INFO, "stop: DBG0 callback entered");
 
 	/* OBS may re-enter this callback (e.g. obs_output_release on an active
 	 * output).  Bail out if we've already torn down so the disconnect log

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -46,18 +46,36 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 	return context;
 }
 
-static void radio_output_destroy(void *data)
+/*
+ * radio_output_teardown — idempotent teardown used by both the stop and
+ * destroy callbacks.  Must be called before freeing the context itself.
+ *
+ * Why this lives here: on the OBS_OUTPUT_ERROR path (reconnect gives up →
+ * obs_output_signal_stop), OBS internally marks the output as stopped, so
+ * a subsequent obs_output_stop() becomes a no-op and our stop callback
+ * never fires — only destroy does, via obs_output_release.  Both paths
+ * need identical teardown, including the "Disconnected from …" and
+ * "MP3 send thread stopped" logs, so share one helper.
+ *
+ * The state_mutex guard makes this safe to call from stop AND destroy on
+ * the happy path (stop runs first → state becomes DISCONNECTED → destroy's
+ * call no-ops).
+ */
+static void radio_output_teardown(struct radio_output *context)
 {
-	struct radio_output *context = data;
-	if (!context)
+	pthread_mutex_lock(&context->state_mutex);
+	if (context->state == RADIO_STATE_DISCONNECTED) {
+		pthread_mutex_unlock(&context->state_mutex);
 		return;
+	}
+	pthread_mutex_unlock(&context->state_mutex);
 
-	obs_log(LOG_INFO, "destroy: DBG-D0 callback entered");
+	/* Stop the audio callback BEFORE freeing anything it touches. */
+	obs_output_end_data_capture(context->output);
+
 	reconnect_cancel(context);
-	obs_log(LOG_INFO, "destroy: DBG-D1 after reconnect_cancel");
 
 #ifdef HAVE_LAME
-	/* Guard against destroy being called without stop (e.g. Lua GC). */
 	if (context->send_buf) {
 		context->send_running = false;
 		pthread_mutex_lock(&context->send_mutex);
@@ -68,22 +86,48 @@ static void radio_output_destroy(void *data)
 		pthread_cond_destroy(&context->send_cond);
 		bfree(context->send_buf);
 		context->send_buf = NULL;
+		obs_log(LOG_INFO, "MP3 send thread stopped");
 	}
-#endif
+#endif /* HAVE_LAME */
 
 #ifdef HAVE_LIBSHOUT
-	if (context->shout) {
-		shout_close(context->shout);
-		shout_free(context->shout);
-	}
-	shout_shutdown();
-#endif
-
 #ifdef HAVE_LAME
+	/* Flush remaining MP3 frames before closing the connection. */
+	if (context->lame_gfp && context->shout) {
+		uint8_t flush_buf[7200];
+		int flush_bytes = lame_encode_flush(context->lame_gfp, flush_buf, sizeof(flush_buf));
+		if (flush_bytes > 0) {
+			int flush_ret = shout_send(context->shout, flush_buf, (size_t)flush_bytes);
+			if (flush_ret != SHOUTERR_SUCCESS)
+				obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
+		}
+	}
 	if (context->lame_gfp) {
 		lame_close(context->lame_gfp);
 		context->lame_gfp = NULL;
 	}
+#endif /* HAVE_LAME */
+	if (context->shout) {
+		shout_close(context->shout);
+		shout_free(context->shout);
+		context->shout = NULL;
+	}
+#endif /* HAVE_LIBSHOUT */
+
+	set_state(context, RADIO_STATE_DISCONNECTED);
+	obs_log(LOG_INFO, "Disconnected from %s:%d%s", context->host, context->port, context->mount);
+}
+
+static void radio_output_destroy(void *data)
+{
+	struct radio_output *context = data;
+	if (!context)
+		return;
+
+	radio_output_teardown(context);
+
+#ifdef HAVE_LIBSHOUT
+	shout_shutdown();
 #endif
 
 	pthread_mutex_destroy(&context->state_mutex);
@@ -371,80 +415,7 @@ start_fail_after_capture:
 static void radio_output_stop(void *data, uint64_t ts)
 {
 	UNUSED_PARAMETER(ts);
-	struct radio_output *context = data;
-
-	obs_log(LOG_INFO, "stop: DBG0 callback entered");
-
-	/* OBS may re-enter this callback (e.g. obs_output_release on an active
-	 * output).  Bail out if we've already torn down so the disconnect log
-	 * and end_data_capture fire exactly once. */
-	pthread_mutex_lock(&context->state_mutex);
-	if (context->state == RADIO_STATE_DISCONNECTED) {
-		pthread_mutex_unlock(&context->state_mutex);
-		return;
-	}
-	pthread_mutex_unlock(&context->state_mutex);
-
-	obs_log(LOG_INFO, "stop: DBG1 before end_data_capture");
-	/* Stop the audio callback BEFORE freeing anything it touches.  Otherwise
-	 * an in-flight raw_audio callback races with the teardown below and can
-	 * use-after-free context->send_buf / lame_gfp. */
-	obs_output_end_data_capture(context->output);
-	obs_log(LOG_INFO, "stop: DBG2 after end_data_capture");
-
-	/* Cancel any in-progress reconnect before touching the shout handle. */
-	reconnect_cancel(context);
-	obs_log(LOG_INFO, "stop: DBG3 after reconnect_cancel");
-
-#ifdef HAVE_LAME
-	/* Stop the MP3 sender thread before closing the shout handle. */
-	if (context->send_buf) {
-		obs_log(LOG_INFO, "stop: DBG4 send_buf set, signaling send thread");
-		context->send_running = false;
-		pthread_mutex_lock(&context->send_mutex);
-		pthread_cond_signal(&context->send_cond);
-		pthread_mutex_unlock(&context->send_mutex);
-		obs_log(LOG_INFO, "stop: DBG5 signal sent, about to join");
-		pthread_join(context->send_thread, NULL);
-		obs_log(LOG_INFO, "stop: DBG6 send thread joined");
-		pthread_mutex_destroy(&context->send_mutex);
-		obs_log(LOG_INFO, "stop: DBG7 mutex destroyed");
-		pthread_cond_destroy(&context->send_cond);
-		obs_log(LOG_INFO, "stop: DBG8 cond destroyed");
-		bfree(context->send_buf);
-		context->send_buf = NULL;
-		obs_log(LOG_INFO, "MP3 send thread stopped");
-	} else {
-		obs_log(LOG_INFO, "stop: DBG4-skip send_buf was NULL");
-	}
-#endif /* HAVE_LAME */
-
-#ifdef HAVE_LIBSHOUT
-#ifdef HAVE_LAME
-	/* Flush remaining MP3 frames before closing the connection. */
-	if (context->lame_gfp && context->shout) {
-		uint8_t flush_buf[7200];
-		int flush_bytes = lame_encode_flush(context->lame_gfp, flush_buf, sizeof(flush_buf));
-		if (flush_bytes > 0) {
-			int flush_ret = shout_send(context->shout, flush_buf, (size_t)flush_bytes);
-			if (flush_ret != SHOUTERR_SUCCESS)
-				obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
-		}
-	}
-	if (context->lame_gfp) {
-		lame_close(context->lame_gfp);
-		context->lame_gfp = NULL;
-	}
-#endif /* HAVE_LAME */
-	if (context->shout) {
-		shout_close(context->shout);
-		shout_free(context->shout);
-		context->shout = NULL;
-	}
-#endif /* HAVE_LIBSHOUT */
-
-	set_state(context, RADIO_STATE_DISCONNECTED);
-	obs_log(LOG_INFO, "Disconnected from %s:%d%s", context->host, context->port, context->mount);
+	radio_output_teardown((struct radio_output *)data);
 }
 
 static void radio_output_raw_audio(void *data, struct audio_data *frames)

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -381,27 +381,37 @@ static void radio_output_stop(void *data, uint64_t ts)
 	}
 	pthread_mutex_unlock(&context->state_mutex);
 
+	obs_log(LOG_INFO, "stop: DBG1 before end_data_capture");
 	/* Stop the audio callback BEFORE freeing anything it touches.  Otherwise
 	 * an in-flight raw_audio callback races with the teardown below and can
 	 * use-after-free context->send_buf / lame_gfp. */
 	obs_output_end_data_capture(context->output);
+	obs_log(LOG_INFO, "stop: DBG2 after end_data_capture");
 
 	/* Cancel any in-progress reconnect before touching the shout handle. */
 	reconnect_cancel(context);
+	obs_log(LOG_INFO, "stop: DBG3 after reconnect_cancel");
 
 #ifdef HAVE_LAME
 	/* Stop the MP3 sender thread before closing the shout handle. */
 	if (context->send_buf) {
+		obs_log(LOG_INFO, "stop: DBG4 send_buf set, signaling send thread");
 		context->send_running = false;
 		pthread_mutex_lock(&context->send_mutex);
 		pthread_cond_signal(&context->send_cond);
 		pthread_mutex_unlock(&context->send_mutex);
+		obs_log(LOG_INFO, "stop: DBG5 signal sent, about to join");
 		pthread_join(context->send_thread, NULL);
+		obs_log(LOG_INFO, "stop: DBG6 send thread joined");
 		pthread_mutex_destroy(&context->send_mutex);
+		obs_log(LOG_INFO, "stop: DBG7 mutex destroyed");
 		pthread_cond_destroy(&context->send_cond);
+		obs_log(LOG_INFO, "stop: DBG8 cond destroyed");
 		bfree(context->send_buf);
 		context->send_buf = NULL;
 		obs_log(LOG_INFO, "MP3 send thread stopped");
+	} else {
+		obs_log(LOG_INFO, "stop: DBG4-skip send_buf was NULL");
 	}
 #endif /* HAVE_LAME */
 

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -127,7 +127,39 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout)
 	shout_set_audio_info(shout, SHOUT_AI_SAMPLERATE, ai_samplerate);
 	shout_set_audio_info(shout, SHOUT_AI_CHANNELS, "2");
 }
-#endif
+
+/*
+ * shout_handoff_cleanup — close + free a libshout handle on a detached
+ * thread so a graceful protocol-close on a half-dead socket doesn't block
+ * the caller.  libshout 2.4.6's shout_close() writes a goodbye message;
+ * if the peer is gone but no TCP RST has arrived, that send() blocks
+ * until the kernel TCP timeout (~60 s on macOS).  Calling shout_free()
+ * alone would leak the connection + fd (libshout 2.4.6 quirk: shout_free
+ * does not call shout_connection_unref).  A detached thread lets the
+ * kernel reap the blocked close whenever the TCP timeout fires.
+ */
+static void *shout_close_detached(void *data)
+{
+	shout_t *handle = data;
+	shout_close(handle);
+	shout_free(handle);
+	return NULL;
+}
+
+static void shout_handoff_cleanup(shout_t *handle)
+{
+	if (!handle)
+		return;
+	pthread_t tid;
+	if (pthread_create(&tid, NULL, shout_close_detached, handle) != 0) {
+		obs_log(LOG_WARNING, "pthread_create for shout cleanup failed; closing inline");
+		shout_close(handle);
+		shout_free(handle);
+		return;
+	}
+	pthread_detach(tid);
+}
+#endif /* HAVE_LIBSHOUT */
 
 #ifdef HAVE_LAME
 /*
@@ -174,9 +206,9 @@ static void *mp3_send_thread(void *data)
 		int ret = shout_send(context->shout, scratch, to_read);
 		if (ret != SHOUTERR_SUCCESS) {
 			obs_log(LOG_ERROR, "[send-thread] shout_send() failed: %s", shout_get_error(context->shout));
-			shout_close(context->shout);
-			shout_free(context->shout);
+			shout_t *dead = context->shout;
 			context->shout = NULL;
+			shout_handoff_cleanup(dead);
 			if (context->reconnect_enabled) {
 				reconnect_start(context);
 			} else {

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -381,6 +381,11 @@ static void radio_output_stop(void *data, uint64_t ts)
 	}
 	pthread_mutex_unlock(&context->state_mutex);
 
+	/* Stop the audio callback BEFORE freeing anything it touches.  Otherwise
+	 * an in-flight raw_audio callback races with the teardown below and can
+	 * use-after-free context->send_buf / lame_gfp. */
+	obs_output_end_data_capture(context->output);
+
 	/* Cancel any in-progress reconnect before touching the shout handle. */
 	reconnect_cancel(context);
 
@@ -426,7 +431,6 @@ static void radio_output_stop(void *data, uint64_t ts)
 
 	set_state(context, RADIO_STATE_DISCONNECTED);
 	obs_log(LOG_INFO, "Disconnected from %s:%d%s", context->host, context->port, context->mount);
-	obs_output_end_data_capture(context->output);
 }
 
 static void radio_output_raw_audio(void *data, struct audio_data *frames)


### PR DESCRIPTION
**Summary**

Multi-commit fix for the error-state → Stop teardown issues on the Phase 1 Test 5 code path. Three bugs, three fixes — all on the same branch.

**Root causes, in order of discovery:**

1. **Synchronous `shout_close` on a dead socket blocks ~57 s** — libshout 2.4.6's `shout_close()` writes a graceful protocol-close message; on a half-dead socket that `send()` blocks until the kernel TCP timeout.
2. **In-flight audio callback races with teardown** — `obs_output_end_data_capture` was the LAST call in `radio_output_stop`, so the audio callback can UAF on `context->send_buf` mid-teardown.
3. **`obs_output_signal_stop(OBS_OUTPUT_ERROR)` makes subsequent `obs_output_stop` a no-op** — our stop callback was NEVER called on the error path. Only `radio_output_destroy` ran via `obs_output_release`, and destroy didn't have the cleanup logs or full teardown logic. That's why earlier fixes seemed to have no effect: stop was bypassed entirely.

**Commits:**

- **549e89e** `fix(send): defer shout_close to detached thread to avoid TCP timeout hang` — new `shout_handoff_cleanup()` pushes the dead `shout_t *` to a detached worker. Kernel reaps the blocked close off-path; send thread continues.
- **08f9c67** `fix(stop): call end_data_capture first to prevent audio callback UAF` — moves `obs_output_end_data_capture` to the start of teardown so audio callback is unregistered before anything is freed.
- **caa0bae / 89ae897** — diagnostic logging commits used to pinpoint the OBS_OUTPUT_ERROR bypass (DBG markers). Removed in 4e23588.
- **4e23588** `fix(destroy): share teardown helper so OBS_OUTPUT_ERROR path logs and frees correctly` — extracts `radio_output_teardown()` and calls it from both stop and destroy. Idempotent via state-mutex guard. Both paths now log "MP3 send thread stopped" and "Disconnected from …" correctly.

**Follow-up (Phase 3 stretch, tracked in `plan.md`):** migrate to libshout's `SHOUT_BLOCKING_NONE` mode as the long-term root fix for commit 1, which would retire the detached cleanup thread.

**Test plan**

- [x] CI passes (clang-format, CMake format, build × 4 platforms, CodeQL, Clang-Tidy, check-commits)

### Setup

```bash
cd ~/Code/Tech-Noid-Systems/obs-radio-output
git fetch origin fix/send-thread-error-stop-hang
git checkout fix/send-thread-error-stop-hang
./build-and-install-macos.sh

# Confirm fix is in the binary
strings ~/Library/Application\ Support/obs-studio/plugins/obs-radio-output.plugin/Contents/MacOS/obs-radio-output | grep -E "MP3 send thread stopped|Disconnected from"
# Expect both strings present
```

**⌘Q OBS completely** (not just close the window), then relaunch.

Icecast:
```bash
docker rm -f icecast 2>/dev/null
docker run -d --name icecast -p 8000:8000 moul/icecast
```

Tail the OBS log in a separate terminal:
```bash
tail -F ~/Library/Application\ Support/obs-studio/logs/*.txt
```

Load **Tools → Scripts → (+) → `scripts/radio-test.lua`**. Open VLC on `http://localhost:8000/stream`.

### Test 5 — Max-retry → Stop (PRIMARY target) ✅ PASS

1. Click **Start Radio Output**. Confirm `Connected to localhost:8000/stream` + `MP3 send thread started`. VLC plays.
2. `docker stop icecast`
3. Watch the log for `shout_send() failed`, reconnect attempts, `max retries (10) exceeded — giving up`.
4. Click **Stop Radio Output**.
5. Watch for, in order, within ~150 ms of clicking:
   - `[reconnect] reconnect thread stopped`
   - `MP3 send thread stopped` ← was missing before
   - `Disconnected from localhost:8000/stream` ← was missing before

**Pass criteria (all must hold):**
- [x] Total from Stop-click to final `Disconnected` line < 200 ms (all three lines fire within the same millisecond)
- [x] Exactly one `Disconnected from localhost:8000/stream` line
- [x] No crash, no DiagnosticReports entry
- [x] OBS remains responsive, audio meters keep moving for your sources

### Test 6 — Happy-path stop (regression) ✅ PASS

1. `docker start icecast` (wait ~2 s). Click Start, confirm `Connected` and playback. Let run ~10 s.
2. Click Stop.

**Pass:**
- [x] Stop duration ~1 ms
- [x] Log order: `MP3 send thread stopped` → `Disconnected from …`
- [x] Exactly one `Disconnected` line (destroy's teardown no-oped via state guard)

### Test 4 — Reconnect happy path (regression) ✅ PASS

1. Start, wait for `Connected`, VLC plays.
2. `docker restart icecast`
3. Log shows `shout_send() failed` → reconnect attempts → `reconnected to …`
4. Stop.

**Pass:**
- [x] Successful reconnect within retry window (reconnected ~400 ms after attempt 1)
- [x] `shout_send` resumes succeeding
- [x] Subsequent stop < 200 ms with all three final logs present

### Soak test — no fd leak, no residual hang ✅ PASS

1. `OBS_PID=$(pgrep -n OBS); lsof -p $OBS_PID | wc -l` — record baseline.
2. Run Test 5 three times in a row, ~5 s between iterations. Don't quit OBS.
3. Immediately after 3rd: `lsof -p $OBS_PID | wc -l` — record.
4. Wait 90 s: `lsof -p $OBS_PID | wc -l` — record.
5. Run Test 6 — verify still works after 3 error cycles.

**Pass:**
- [x] Immediately after 3rd error: fd count ≤ baseline + ~10 (baseline 173 → post-3rd 173; zero drift)
- [x] After 90 s: fd count returns to ~baseline (still 173)
- [x] No `pthread_create for shout cleanup failed` warnings
- [x] Test 6 after soak still has clean final logs

### If a test fails

- Full OBS log: `~/Library/Application Support/obs-studio/logs/*.txt`
- Stack sample during stuck state: `sample OBS 5 -file /tmp/obs-hang.txt`
- Crash reports: `ls ~/Library/Logs/DiagnosticReports/ | grep -i obs`
- Note which test + step, share the log line before the failure.