### PR TITLE
feat(ui): Tools menu config dialog for Radio Output

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,23 @@
+---
+Checks: >-
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  misc-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -misc-include-cleaner,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -readability-function-cognitive-complexity,
+  -readability-redundant-casting
+WarningsAsErrors: ""
+HeaderFilterRegex: "src/.*"
+FormatStyle: "file"
+CheckOptions:
+  - key: readability-identifier-length.MinimumVariableNameLength
+    value: "2"
+  - key: readability-identifier-length.MinimumParameterNameLength
+    value: "2"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >-
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
   -misc-include-cleaner,
   -readability-braces-around-statements,
+  -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-function-cognitive-complexity,
   -readability-redundant-casting

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      security-events: write
+      checks: write
       pull-requests: write
     defaults:
       run:
@@ -29,17 +29,32 @@ jobs:
           target: x86_64
           config: RelWithDebInfo
 
-      - name: Run Clang-Tidy 🔬
-        uses: cpp-linter/cpp-linter-action@v2
-        id: linter
+      - name: Show Compile Commands 🔍
+        run: |
+          : # Verify the build produced compile_commands.json with the expected
+          : # entries for the Phase 2 UI sources; without this clang-tidy can't
+          : # parse C++ files correctly.
+          if [[ -f build_x86_64/compile_commands.json ]]; then
+            echo "::group::compile_commands.json entries for Phase 2 UI sources"
+            jq '.[] | select(.file | test("frontend-wire|config-dialog"))' \
+              build_x86_64/compile_commands.json || true
+            echo "::endgroup::"
+          else
+            echo "::warning::build_x86_64/compile_commands.json missing — clang-tidy will lack per-file flags"
+          fi
+
+      - name: Setup reviewdog 🐕
+        uses: reviewdog/action-setup@v1
+
+      - name: Run Clang-Tidy via reviewdog 🔬
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: ''
-          tidy-checks: ''
-          database: build_x86_64
-          files-changed-only: true
-          thread-comments: true
-          tidy-review: true
-          format-review: false
-          step-summary: true
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          clang-tidy -p=build_x86_64 src/*.c src/*.cpp 2>&1 | \
+            reviewdog \
+              -f=clang-tidy \
+              -name=clang-tidy \
+              -reporter=github-pr-check \
+              -level=warning \
+              -filter-mode=added

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -54,7 +54,15 @@ jobs:
           : # red-check the job.  Disable pipefail for this step and capture
           : # the raw output to a file for the next step to consume.
           set +o pipefail
-          clang-tidy -p=build_x86_64 src/*.c src/*.cpp > clang-tidy.log 2>&1 || true
+          : # --extra-arg=-Wno-unknown-warning-option lets clang-tidy skip
+          : # GCC-specific flags like -Werror=maybe-uninitialized /
+          : # -Wno-stringop-overflow that OBS's build config adds.  Without
+          : # this, clang-tidy errors at command-line processing before
+          : # analyzing any code.
+          clang-tidy \
+            --extra-arg=-Wno-unknown-warning-option \
+            -p=build_x86_64 src/*.c src/*.cpp \
+            > clang-tidy.log 2>&1 || true
           echo "::group::clang-tidy raw output"
           cat clang-tidy.log
           echo "::endgroup::"

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -46,25 +46,31 @@ jobs:
       - name: Setup reviewdog 🐕
         uses: reviewdog/action-setup@v1
 
-      - name: Run Clang-Tidy via reviewdog 🔬
+      - name: Run Clang-Tidy 🔬
+        run: |
+          : # GitHub Actions' default bash shell runs with `-e -o pipefail`
+          : # baked in, so clang-tidy's non-zero exit (it returns non-zero
+          : # whenever any diagnostic is emitted) would fail the step and
+          : # red-check the job.  Disable pipefail for this step and capture
+          : # the raw output to a file for the next step to consume.
+          set +o pipefail
+          clang-tidy -p=build_x86_64 src/*.c src/*.cpp > clang-tidy.log 2>&1 || true
+          echo "::group::clang-tidy raw output"
+          cat clang-tidy.log
+          echo "::endgroup::"
+
+      - name: Post annotations via reviewdog 🐕
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           : # reviewdog doesn't ship a built-in parser for clang-tidy; feed it
-          : # an -efm (vim errorformat) pattern that matches the standard
+          : # -efm (vim errorformat) patterns that match the standard
           : # "file:line:col: severity: message [check-name]" output format.
-          : #
-          : # We intentionally do NOT use `set -o pipefail` here: clang-tidy
-          : # exits non-zero whenever it emits any diagnostic, and that would
-          : # make the step red even when reviewdog successfully posts the
-          : # findings as annotations.  The tee preserves the raw output in
-          : # the job log for debugging.
-          clang-tidy -p=build_x86_64 src/*.c src/*.cpp 2>&1 \
-            | tee clang-tidy.log \
-            | reviewdog \
-                -efm='%f:%l:%c: %tarning: %m' \
-                -efm='%f:%l:%c: %trror: %m' \
-                -name=clang-tidy \
-                -reporter=github-pr-check \
-                -level=warning \
-                -filter-mode=added
+          reviewdog \
+            -efm='%f:%l:%c: %tarning: %m' \
+            -efm='%f:%l:%c: %trror: %m' \
+            -name=clang-tidy \
+            -reporter=github-pr-check \
+            -level=warning \
+            -filter-mode=added \
+            < clang-tidy.log

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -46,4 +46,3 @@ jobs:
           tidy-review: true
           format-review: false
           step-summary: true
-          extra-args: '-std=c99'

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -50,10 +50,14 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          : # reviewdog doesn't ship a built-in parser for clang-tidy; feed it
+          : # an -efm (vim errorformat) pattern that matches the standard
+          : # "file:line:col: severity: message [check-name]" output format.
           set -o pipefail
           clang-tidy -p=build_x86_64 src/*.c src/*.cpp 2>&1 | \
             reviewdog \
-              -f=clang-tidy \
+              -efm='%f:%l:%c: %tarning: %m' \
+              -efm='%f:%l:%c: %trror: %m' \
               -name=clang-tidy \
               -reporter=github-pr-check \
               -level=warning \

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -53,12 +53,18 @@ jobs:
           : # reviewdog doesn't ship a built-in parser for clang-tidy; feed it
           : # an -efm (vim errorformat) pattern that matches the standard
           : # "file:line:col: severity: message [check-name]" output format.
-          set -o pipefail
-          clang-tidy -p=build_x86_64 src/*.c src/*.cpp 2>&1 | \
-            reviewdog \
-              -efm='%f:%l:%c: %tarning: %m' \
-              -efm='%f:%l:%c: %trror: %m' \
-              -name=clang-tidy \
-              -reporter=github-pr-check \
-              -level=warning \
-              -filter-mode=added
+          : #
+          : # We intentionally do NOT use `set -o pipefail` here: clang-tidy
+          : # exits non-zero whenever it emits any diagnostic, and that would
+          : # make the step red even when reviewdog successfully posts the
+          : # findings as annotations.  The tee preserves the raw output in
+          : # the job log for debugging.
+          clang-tidy -p=build_x86_64 src/*.c src/*.cpp 2>&1 \
+            | tee clang-tidy.log \
+            | reviewdog \
+                -efm='%f:%l:%c: %tarning: %m' \
+                -efm='%f:%l:%c: %trror: %m' \
+                -name=clang-tidy \
+                -reporter=github-pr-check \
+                -level=warning \
+                -filter-mode=added

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -29,9 +29,6 @@ jobs:
           target: x86_64
           config: RelWithDebInfo
 
-      - name: Enable Compile Commands 🗂️
-        run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
       - name: Run Clang-Tidy 🔬
         uses: cpp-linter/cpp-linter-action@v2
         id: linter
@@ -40,7 +37,7 @@ jobs:
         with:
           style: ''
           tidy-checks: ''
-          database: build
+          database: build_x86_64
           files-changed-only: true
           thread-comments: true
           tidy-review: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /*
 
 # Except for default project files
+!/.clang-tidy
 !/.github
 !/build-aux
 !/cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ project(${_name} VERSION ${_version})
 
 set(PLUGIN_LICENSE "GPL-2.0-or-later")
 
-option(ENABLE_FRONTEND_API "Use obs-frontend-api for UI functionality" OFF)
-option(ENABLE_QT "Use Qt functionality" OFF)
+option(ENABLE_FRONTEND_API "Use obs-frontend-api for UI functionality" ON)
+option(ENABLE_QT "Use Qt functionality" ON)
 
 include(compilerconfig)
 include(defaults)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,15 +71,16 @@ endif()
 
 target_sources(
   ${CMAKE_PROJECT_NAME}
-  PRIVATE src/plugin-main.c
-          src/radio-output.c
-          src/radio-output.h
-          src/reconnect.c
-          src/reconnect.h
-          src/frontend-wire.cpp
-          src/frontend-wire.h
-          src/radio-output-config-dialog.cpp
-          src/radio-output-config-dialog.hpp
+  PRIVATE
+    src/plugin-main.c
+    src/radio-output.c
+    src/radio-output.h
+    src/reconnect.c
+    src/reconnect.h
+    src/frontend-wire.cpp
+    src/frontend-wire.h
+    src/radio-output-config-dialog.cpp
+    src/radio-output-config-dialog.hpp
 )
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,15 @@ endif()
 
 target_sources(
   ${CMAKE_PROJECT_NAME}
-  PRIVATE src/plugin-main.c src/radio-output.c src/radio-output.h src/reconnect.c src/reconnect.h
+  PRIVATE src/plugin-main.c
+          src/radio-output.c
+          src/radio-output.h
+          src/reconnect.c
+          src/reconnect.h
+          src/frontend-wire.cpp
+          src/frontend-wire.h
+          src/radio-output-config-dialog.cpp
+          src/radio-output-config-dialog.hpp
 )
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,8 +10,8 @@
       "name": "template",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FRONTEND_API": false,
-        "ENABLE_QT": false
+        "ENABLE_FRONTEND_API": true,
+        "ENABLE_QT": true
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,7 +11,8 @@
       "hidden": true,
       "cacheVariables": {
         "ENABLE_FRONTEND_API": true,
-        "ENABLE_QT": true
+        "ENABLE_QT": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -23,10 +23,27 @@ Stream audio from OBS Studio directly to Icecast and SHOUTcast internet radio se
 
 ## Building from Source
 
+### Prerequisites for contributors
+
+In addition to the per-platform build prerequisites below, contributors need these local tools to pass CI-equivalent checks before pushing:
+
+- **clang-format (≥ 16)** — enforces C/C++ formatting. CI runs it via `.clang-format`. Install:
+  - macOS: `brew install clang-format`
+  - Ubuntu: `apt install clang-format`
+  - Windows: via Visual Studio (bundled) or `winget install LLVM.LLVM`
+- **gersemi** — enforces CMake formatting. Install: `brew install gersemi` (macOS) or `pipx install gersemi` (any platform with Python).
+
+Run both locally before committing any changes that touch source or CMake files:
+
+```bash
+clang-format -i src/*.c src/*.h src/*.cpp src/*.hpp
+gersemi -i CMakeLists.txt
+```
+
 ### macOS
 
 **Prerequisites:** Xcode Command Line Tools and [Homebrew](https://brew.sh). All other
-dependencies (CMake, autotools, libshout) are installed automatically by the setup script.
+dependencies (CMake, autotools, libshout, libmp3lame, Qt6) are installed automatically by the setup script.
 
 ```zsh
 git clone https://github.com/tech-noid-systems/obs-radio-output.git

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -16,3 +16,9 @@ RadioOutput.Reconnect.Group=Auto-Reconnect
 RadioOutput.Reconnect.Enable=Reconnect on Disconnect
 RadioOutput.Reconnect.Delay=Delay (seconds)
 RadioOutput.Reconnect.Max=Max Retry Attempts
+
+RadioOutput.Integration.Group=OBS Integration
+RadioOutput.StartWithStreaming=Start/stop radio with OBS streaming
+
+RadioOutput.Menu.OpenConfig=Radio Output…
+RadioOutput.Config.Title=Radio Output Configuration

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,24 +1,24 @@
-RadioOutput.Name=Radio Output (Icecast/SHOUTcast)
+RadioOutput.Name="Radio Output (Icecast/SHOUTcast)"
 
-RadioOutput.Server.Group=Server
-RadioOutput.Server.Host=Host
-RadioOutput.Server.Port=Port
-RadioOutput.Server.Mount=Mount Point
-RadioOutput.Server.Password=Password
+RadioOutput.Server.Group="Server"
+RadioOutput.Server.Host="Host"
+RadioOutput.Server.Port="Port"
+RadioOutput.Server.Mount="Mount Point"
+RadioOutput.Server.Password="Password"
 
-RadioOutput.Audio.Group=Audio
-RadioOutput.Audio.Codec=Codec
-RadioOutput.Audio.Codec.Opus=Opus
-RadioOutput.Audio.Codec.MP3=MP3
-RadioOutput.Audio.Bitrate=Bitrate (kbps)
+RadioOutput.Audio.Group="Audio"
+RadioOutput.Audio.Codec="Codec"
+RadioOutput.Audio.Codec.Opus="Opus"
+RadioOutput.Audio.Codec.MP3="MP3"
+RadioOutput.Audio.Bitrate="Bitrate (kbps)"
 
-RadioOutput.Reconnect.Group=Auto-Reconnect
-RadioOutput.Reconnect.Enable=Reconnect on Disconnect
-RadioOutput.Reconnect.Delay=Delay (seconds)
-RadioOutput.Reconnect.Max=Max Retry Attempts
+RadioOutput.Reconnect.Group="Auto-Reconnect"
+RadioOutput.Reconnect.Enable="Reconnect on Disconnect"
+RadioOutput.Reconnect.Delay="Delay (seconds)"
+RadioOutput.Reconnect.Max="Max Retry Attempts"
 
-RadioOutput.Integration.Group=OBS Integration
-RadioOutput.StartWithStreaming=Start/stop radio with OBS streaming
+RadioOutput.Integration.Group="OBS Integration"
+RadioOutput.StartWithStreaming="Start/stop radio with OBS streaming"
 
-RadioOutput.Menu.OpenConfig=Radio Output…
-RadioOutput.Config.Title=Radio Output Configuration
+RadioOutput.Menu.OpenConfig="Radio Output…"
+RadioOutput.Config.Title="Radio Output Configuration"

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -128,7 +128,8 @@ extern "C" void frontend_wire_load(void)
 {
 	load_config_from_disk();
 
-	obs_frontend_add_tools_menu_item(obs_module_text("RadioOutput.Menu.OpenConfig"), on_tools_menu_clicked, nullptr);
+	obs_frontend_add_tools_menu_item(obs_module_text("RadioOutput.Menu.OpenConfig"), on_tools_menu_clicked,
+					 nullptr);
 }
 
 extern "C" void frontend_wire_unload(void)

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include "frontend-wire.h"
+
+#include <obs-frontend-api.h>
+#include <obs-module.h>
+#include <plugin-support.h>
+#include <util/bmem.h>
+#include <util/platform.h>
+
+#include <QMainWindow>
+#include <QString>
+
+#include <string>
+
+#include "radio-output-config-dialog.hpp"
+#include "radio-output.h"
+
+namespace {
+
+constexpr const char *kConfigFileName = "config.json";
+
+/* Module-global config.  Owned by this translation unit. */
+obs_data_t *g_config = nullptr;
+
+std::string config_file_path()
+{
+	char *raw = obs_module_config_path(kConfigFileName);
+	if (!raw)
+		return {};
+	std::string path(raw);
+	bfree(raw);
+	return path;
+}
+
+std::string config_dir_path()
+{
+	char *raw = obs_module_config_path("");
+	if (!raw)
+		return {};
+	std::string path(raw);
+	bfree(raw);
+	/* Trim trailing slash if present so os_mkdirs treats the dir correctly. */
+	while (!path.empty() && (path.back() == '/' || path.back() == '\\'))
+		path.pop_back();
+	return path;
+}
+
+void apply_defaults(obs_data_t *data)
+{
+	obs_data_set_default_string(data, SETTING_HOST, "localhost");
+	obs_data_set_default_int(data, SETTING_PORT, 8000);
+	obs_data_set_default_string(data, SETTING_MOUNT, "/stream");
+	obs_data_set_default_string(data, SETTING_PASSWORD, "");
+	obs_data_set_default_int(data, SETTING_CODEC, RADIO_CODEC_MP3);
+	obs_data_set_default_int(data, SETTING_BITRATE, 128);
+	obs_data_set_default_bool(data, SETTING_RECONNECT, true);
+	obs_data_set_default_int(data, SETTING_RECONNECT_DELAY, 5);
+	obs_data_set_default_int(data, SETTING_RECONNECT_MAX, 10);
+	obs_data_set_default_bool(data, SETTING_START_WITH_STREAMING, false);
+}
+
+void load_config_from_disk()
+{
+	std::string path = config_file_path();
+	if (path.empty()) {
+		g_config = obs_data_create();
+	} else if (os_file_exists(path.c_str())) {
+		g_config = obs_data_create_from_json_file(path.c_str());
+		if (!g_config) {
+			obs_log(LOG_WARNING, "[frontend-wire] failed to parse %s; using defaults", path.c_str());
+			g_config = obs_data_create();
+		}
+	} else {
+		g_config = obs_data_create();
+	}
+	apply_defaults(g_config);
+}
+
+void save_config_to_disk()
+{
+	if (!g_config)
+		return;
+
+	std::string dir = config_dir_path();
+	if (!dir.empty())
+		os_mkdirs(dir.c_str());
+
+	std::string path = config_file_path();
+	if (path.empty())
+		return;
+
+	if (!obs_data_save_json_safe(g_config, path.c_str(), ".tmp", ".bak"))
+		obs_log(LOG_WARNING, "[frontend-wire] failed to save config to %s", path.c_str());
+}
+
+void on_tools_menu_clicked(void *)
+{
+	if (!g_config)
+		return;
+
+	auto *parent = reinterpret_cast<QMainWindow *>(obs_frontend_get_main_window());
+	RadioOutputConfigDialog dialog(g_config, parent);
+	if (dialog.exec() == QDialog::Accepted)
+		save_config_to_disk();
+}
+
+} // namespace
+
+extern "C" void frontend_wire_load(void)
+{
+	load_config_from_disk();
+
+	obs_frontend_add_tools_menu_item(obs_module_text("RadioOutput.Menu.OpenConfig"), on_tools_menu_clicked, nullptr);
+}
+
+extern "C" void frontend_wire_unload(void)
+{
+	save_config_to_disk();
+
+	if (g_config) {
+		obs_data_release(g_config);
+		g_config = nullptr;
+	}
+}
+
+extern "C" obs_data_t *frontend_wire_get_config(void)
+{
+	return g_config;
+}

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -79,18 +79,14 @@ void apply_defaults(obs_data_t *data)
 
 void load_config_from_disk()
 {
-	std::string path = config_file_path();
-	if (path.empty()) {
-		g_config = obs_data_create();
-	} else if (os_file_exists(path.c_str())) {
+	const std::string path = config_file_path();
+	if (!path.empty() && os_file_exists(path.c_str())) {
 		g_config = obs_data_create_from_json_file(path.c_str());
-		if (!g_config) {
+		if (!g_config)
 			obs_log(LOG_WARNING, "[frontend-wire] failed to parse %s; using defaults", path.c_str());
-			g_config = obs_data_create();
-		}
-	} else {
-		g_config = obs_data_create();
 	}
+	if (!g_config)
+		g_config = obs_data_create();
 	apply_defaults(g_config);
 }
 
@@ -99,11 +95,11 @@ void save_config_to_disk()
 	if (!g_config)
 		return;
 
-	std::string dir = config_dir_path();
+	const std::string dir = config_dir_path();
 	if (!dir.empty())
 		os_mkdirs(dir.c_str());
 
-	std::string path = config_file_path();
+	const std::string path = config_file_path();
 	if (path.empty())
 		return;
 
@@ -111,7 +107,7 @@ void save_config_to_disk()
 		obs_log(LOG_WARNING, "[frontend-wire] failed to save config to %s", path.c_str());
 }
 
-void on_tools_menu_clicked(void *)
+void on_tools_menu_clicked(void * /*priv*/)
 {
 	if (!g_config)
 		return;

--- a/src/frontend-wire.h
+++ b/src/frontend-wire.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#pragma once
+
+#include <obs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Called from obs_module_load() after the output is registered.  Loads
+ * any persisted config from disk and registers the Tools menu item.
+ * Safe to call even if obs-frontend-api is not linked (no-op stub).
+ */
+void frontend_wire_load(void);
+
+/*
+ * Called from obs_module_unload().  Persists the current config and
+ * frees module-global resources.
+ */
+void frontend_wire_unload(void);
+
+/*
+ * Returns a pointer to the current configuration obs_data_t.  The
+ * returned data is owned by this module; the caller must NOT release
+ * it.  Use obs_data_get_* to read values under the assumption that the
+ * pointer remains valid for the lifetime of the module.
+ *
+ * Returns NULL if frontend-wire has not yet been loaded.
+ */
+obs_data_t *frontend_wire_get_config(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -19,6 +19,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <obs-module.h>
 #include <plugin-support.h>
+#include "frontend-wire.h"
 #include "radio-output.h"
 
 OBS_DECLARE_MODULE()
@@ -27,11 +28,13 @@ OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 bool obs_module_load(void)
 {
 	obs_register_output(&radio_output_info);
+	frontend_wire_load();
 	obs_log(LOG_INFO, "plugin loaded successfully (version %s)", PLUGIN_VERSION);
 	return true;
 }
 
 void obs_module_unload(void)
 {
+	frontend_wire_unload();
 	obs_log(LOG_INFO, "plugin unloaded");
 }

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -115,7 +115,9 @@ void selectByData(QComboBox *combo, int value)
 
 } // namespace
 
-RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *parent) : QDialog(parent), settings_(settings)
+RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *parent)
+	: QDialog(parent),
+	  settings_(settings)
 {
 	setWindowTitle(obs_module_text("RadioOutput.Config.Title"));
 	setModal(true);

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -67,7 +67,7 @@ QWidget *buildAudioGroup(RadioOutputConfigDialog *parent, QComboBox *&codec, QCo
 	form->addRow(obs_module_text("RadioOutput.Audio.Codec"), codec);
 
 	bitrate = new QComboBox(group);
-	for (int br : kBitrates) {
+	for (const int br : kBitrates) {
 		bitrate->addItem(QString("%1 kbps").arg(br), br);
 	}
 	form->addRow(obs_module_text("RadioOutput.Audio.Bitrate"), bitrate);
@@ -108,7 +108,7 @@ QWidget *buildIntegrationGroup(RadioOutputConfigDialog *parent, QCheckBox *&star
 /* Select the combo entry whose userData matches value; no-op if not present. */
 void selectByData(QComboBox *combo, int value)
 {
-	int idx = combo->findData(value);
+	const int idx = combo->findData(value);
 	if (idx >= 0)
 		combo->setCurrentIndex(idx);
 }

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include "radio-output-config-dialog.hpp"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QVBoxLayout>
+
+#include <obs-module.h>
+
+#include "radio-output.h"
+
+namespace {
+
+/* Common internet-radio bitrates populated into the combo. */
+constexpr int kBitrates[] = {32, 48, 64, 96, 128, 192, 256, 320};
+
+QWidget *buildServerGroup(RadioOutputConfigDialog *parent, QLineEdit *&host, QSpinBox *&port, QLineEdit *&mount,
+			  QLineEdit *&password)
+{
+	auto *group = new QGroupBox(obs_module_text("RadioOutput.Server.Group"), parent);
+	auto *form = new QFormLayout(group);
+
+	host = new QLineEdit(group);
+	form->addRow(obs_module_text("RadioOutput.Server.Host"), host);
+
+	port = new QSpinBox(group);
+	port->setRange(1, 65535);
+	form->addRow(obs_module_text("RadioOutput.Server.Port"), port);
+
+	mount = new QLineEdit(group);
+	form->addRow(obs_module_text("RadioOutput.Server.Mount"), mount);
+
+	password = new QLineEdit(group);
+	password->setEchoMode(QLineEdit::Password);
+	form->addRow(obs_module_text("RadioOutput.Server.Password"), password);
+
+	return group;
+}
+
+QWidget *buildAudioGroup(RadioOutputConfigDialog *parent, QComboBox *&codec, QComboBox *&bitrate)
+{
+	auto *group = new QGroupBox(obs_module_text("RadioOutput.Audio.Group"), parent);
+	auto *form = new QFormLayout(group);
+
+	codec = new QComboBox(group);
+	codec->addItem(obs_module_text("RadioOutput.Audio.Codec.Opus"), RADIO_CODEC_OPUS);
+	codec->addItem(obs_module_text("RadioOutput.Audio.Codec.MP3"), RADIO_CODEC_MP3);
+	form->addRow(obs_module_text("RadioOutput.Audio.Codec"), codec);
+
+	bitrate = new QComboBox(group);
+	for (int br : kBitrates) {
+		bitrate->addItem(QString("%1 kbps").arg(br), br);
+	}
+	form->addRow(obs_module_text("RadioOutput.Audio.Bitrate"), bitrate);
+
+	return group;
+}
+
+QWidget *buildReconnectGroup(RadioOutputConfigDialog *parent, QCheckBox *&enabled, QSpinBox *&delay, QSpinBox *&max)
+{
+	auto *group = new QGroupBox(obs_module_text("RadioOutput.Reconnect.Group"), parent);
+	auto *form = new QFormLayout(group);
+
+	enabled = new QCheckBox(obs_module_text("RadioOutput.Reconnect.Enable"), group);
+	form->addRow(enabled);
+
+	delay = new QSpinBox(group);
+	delay->setRange(1, 300);
+	form->addRow(obs_module_text("RadioOutput.Reconnect.Delay"), delay);
+
+	max = new QSpinBox(group);
+	max->setRange(0, 999);
+	form->addRow(obs_module_text("RadioOutput.Reconnect.Max"), max);
+
+	return group;
+}
+
+QWidget *buildIntegrationGroup(RadioOutputConfigDialog *parent, QCheckBox *&startWithStreaming)
+{
+	auto *group = new QGroupBox(obs_module_text("RadioOutput.Integration.Group"), parent);
+	auto *form = new QFormLayout(group);
+
+	startWithStreaming = new QCheckBox(obs_module_text("RadioOutput.StartWithStreaming"), group);
+	form->addRow(startWithStreaming);
+
+	return group;
+}
+
+/* Select the combo entry whose userData matches value; no-op if not present. */
+void selectByData(QComboBox *combo, int value)
+{
+	int idx = combo->findData(value);
+	if (idx >= 0)
+		combo->setCurrentIndex(idx);
+}
+
+} // namespace
+
+RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *parent) : QDialog(parent), settings_(settings)
+{
+	setWindowTitle(obs_module_text("RadioOutput.Config.Title"));
+	setModal(true);
+
+	auto *layout = new QVBoxLayout(this);
+	layout->addWidget(buildServerGroup(this, host_, port_, mount_, password_));
+	layout->addWidget(buildAudioGroup(this, codec_, bitrate_));
+	layout->addWidget(buildReconnectGroup(this, reconnect_enabled_, reconnect_delay_, reconnect_max_));
+	layout->addWidget(buildIntegrationGroup(this, start_with_streaming_));
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	layout->addWidget(buttons);
+	connect(buttons, &QDialogButtonBox::accepted, this, &RadioOutputConfigDialog::onAccept);
+	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+	/* Populate widgets from the current settings. */
+	host_->setText(QString::fromUtf8(obs_data_get_string(settings_, SETTING_HOST)));
+	port_->setValue((int)obs_data_get_int(settings_, SETTING_PORT));
+	mount_->setText(QString::fromUtf8(obs_data_get_string(settings_, SETTING_MOUNT)));
+	password_->setText(QString::fromUtf8(obs_data_get_string(settings_, SETTING_PASSWORD)));
+	selectByData(codec_, (int)obs_data_get_int(settings_, SETTING_CODEC));
+	selectByData(bitrate_, (int)obs_data_get_int(settings_, SETTING_BITRATE));
+	reconnect_enabled_->setChecked(obs_data_get_bool(settings_, SETTING_RECONNECT));
+	reconnect_delay_->setValue((int)obs_data_get_int(settings_, SETTING_RECONNECT_DELAY));
+	reconnect_max_->setValue((int)obs_data_get_int(settings_, SETTING_RECONNECT_MAX));
+	start_with_streaming_->setChecked(obs_data_get_bool(settings_, SETTING_START_WITH_STREAMING));
+}
+
+void RadioOutputConfigDialog::onAccept()
+{
+	obs_data_set_string(settings_, SETTING_HOST, host_->text().toUtf8().constData());
+	obs_data_set_int(settings_, SETTING_PORT, port_->value());
+	obs_data_set_string(settings_, SETTING_MOUNT, mount_->text().toUtf8().constData());
+	obs_data_set_string(settings_, SETTING_PASSWORD, password_->text().toUtf8().constData());
+	obs_data_set_int(settings_, SETTING_CODEC, codec_->currentData().toInt());
+	obs_data_set_int(settings_, SETTING_BITRATE, bitrate_->currentData().toInt());
+	obs_data_set_bool(settings_, SETTING_RECONNECT, reconnect_enabled_->isChecked());
+	obs_data_set_int(settings_, SETTING_RECONNECT_DELAY, reconnect_delay_->value());
+	obs_data_set_int(settings_, SETTING_RECONNECT_MAX, reconnect_max_->value());
+	obs_data_set_bool(settings_, SETTING_START_WITH_STREAMING, start_with_streaming_->isChecked());
+
+	accept();
+}

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -44,6 +44,7 @@ QWidget *buildServerGroup(RadioOutputConfigDialog *parent, QLineEdit *&host, QSp
 
 	port = new QSpinBox(group);
 	port->setRange(1, 65535);
+	port->setMinimumWidth(100);
 	form->addRow(obs_module_text("RadioOutput.Server.Port"), port);
 
 	mount = new QLineEdit(group);
@@ -85,10 +86,12 @@ QWidget *buildReconnectGroup(RadioOutputConfigDialog *parent, QCheckBox *&enable
 
 	delay = new QSpinBox(group);
 	delay->setRange(1, 300);
+	delay->setMinimumWidth(100);
 	form->addRow(obs_module_text("RadioOutput.Reconnect.Delay"), delay);
 
 	max = new QSpinBox(group);
 	max->setRange(0, 999);
+	max->setMinimumWidth(100);
 	form->addRow(obs_module_text("RadioOutput.Reconnect.Max"), max);
 
 	return group;
@@ -121,6 +124,7 @@ RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *
 {
 	setWindowTitle(obs_module_text("RadioOutput.Config.Title"));
 	setModal(true);
+	setMinimumWidth(420);
 
 	auto *layout = new QVBoxLayout(this);
 	layout->addWidget(buildServerGroup(this, host_, port_, mount_, password_));

--- a/src/radio-output-config-dialog.hpp
+++ b/src/radio-output-config-dialog.hpp
@@ -44,7 +44,7 @@ public:
 private slots:
 	void onAccept();
 
-private:
+private: // NOLINT(readability-redundant-access-specifiers) — keeps data members visually separate from Qt slots
 	obs_data_t *settings_;
 
 	QLineEdit *host_;

--- a/src/radio-output-config-dialog.hpp
+++ b/src/radio-output-config-dialog.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#pragma once
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialog>
+#include <QLineEdit>
+#include <QSpinBox>
+
+#include <obs.h>
+
+/*
+ * Modal configuration dialog for the Radio Output plugin.
+ *
+ * Reads the current settings from the given obs_data_t on construction.
+ * On OK, writes the edited values back into the same obs_data_t and
+ * accepts.  On Cancel, the obs_data_t is untouched.  Persistence to disk
+ * is the caller's responsibility (see frontend-wire.cpp).
+ */
+class RadioOutputConfigDialog : public QDialog {
+	Q_OBJECT
+
+public:
+	explicit RadioOutputConfigDialog(obs_data_t *settings, QWidget *parent = nullptr);
+
+private slots:
+	void onAccept();
+
+private:
+	obs_data_t *settings_;
+
+	QLineEdit *host_;
+	QSpinBox *port_;
+	QLineEdit *mount_;
+	QLineEdit *password_;
+	QComboBox *codec_;
+	QComboBox *bitrate_;
+	QCheckBox *reconnect_enabled_;
+	QSpinBox *reconnect_delay_;
+	QSpinBox *reconnect_max_;
+	QCheckBox *start_with_streaming_;
+};

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -550,6 +550,7 @@ static void radio_output_get_defaults(obs_data_t *settings)
 	obs_data_set_default_bool(settings, SETTING_RECONNECT, true);
 	obs_data_set_default_int(settings, SETTING_RECONNECT_DELAY, 5);
 	obs_data_set_default_int(settings, SETTING_RECONNECT_MAX, 10);
+	obs_data_set_default_bool(settings, SETTING_START_WITH_STREAMING, false);
 }
 
 struct obs_output_info radio_output_info = {

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -98,14 +98,15 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout);
 #endif
 
 // Settings key names (used in obs_data_get_* calls)
-#define SETTING_HOST            "host"
-#define SETTING_PORT            "port"
-#define SETTING_MOUNT           "mount"
-#define SETTING_PASSWORD        "password"
-#define SETTING_CODEC           "codec"
-#define SETTING_BITRATE         "bitrate"
-#define SETTING_RECONNECT       "reconnect_enabled"
-#define SETTING_RECONNECT_DELAY "reconnect_delay"
-#define SETTING_RECONNECT_MAX   "reconnect_max"
+#define SETTING_HOST                 "host"
+#define SETTING_PORT                 "port"
+#define SETTING_MOUNT                "mount"
+#define SETTING_PASSWORD             "password"
+#define SETTING_CODEC                "codec"
+#define SETTING_BITRATE              "bitrate"
+#define SETTING_RECONNECT            "reconnect_enabled"
+#define SETTING_RECONNECT_DELAY      "reconnect_delay"
+#define SETTING_RECONNECT_MAX        "reconnect_max"
+#define SETTING_START_WITH_STREAMING "start_with_streaming"
 
 extern struct obs_output_info radio_output_info;


### PR DESCRIPTION
**Summary**
- First of four PRs for Phase 2 §B (Native properties UI). Adds a **Tools → Radio Output…** menu item that opens a modal QDialog for configuring host / port / mount / password / codec / bitrate / reconnect settings, plus the new **Start/stop radio with OBS streaming** checkbox (wired in §B.3).
- Config persists to `{obs_module_config_path}/config.json` across OBS restarts.
- Flips `ENABLE_FRONTEND_API` and `ENABLE_QT` in both CMake and `CMakePresets.json` — first use of C++/Qt in this plugin. Adds `Qt6::Core Qt6::Widgets` and `OBS::obs-frontend-api` as link deps.
- Introduces module-global config management in `frontend-wire.cpp` — owner of the current `obs_data_t *` that §B.2 (dock) and §B.3 (streaming events) will read from.
- The dialog is a hand-rolled Qt form (QFormLayout + QLineEdit/QSpinBox/QComboBox/QCheckBox) rather than wrapping `OBSPropertiesView`, which isn't cleanly exposed via `obs-frontend-api`. Trade-off: ~170 lines of straightforward Qt vs ~1000 lines of copied properties-view code. Spec note in `implementation.md` §B.1.
- Also modernizes the clang-tidy workflow: migrates from `cpp-linter-action` (persistent PR review comments) to **reviewdog** (ephemeral check annotations), and in the process discovered that `.clang-tidy` was gitignored and never actually in the repo — so CI had been running clang-tidy with default checks instead of our curated config. Fixed as part of this PR.

**Commits** (15 total)

Feature (3):
- `7d6de2e` `ci(cmake): enable frontend-api and Qt6 for Phase 2 UI` — flips option() defaults to ON.
- `647671a` `ci(cmake): enable frontend-api and Qt6 in preset cache variables` — needed because `CMakePresets.json` hidden "template" preset was overriding the option defaults to OFF during CI.
- `fb0359e` `feat(ui): add Tools menu config dialog for server, codec, and reconnect settings` — dialog + frontend-wire + plugin-main hooks + locale + CMake source list.

Formatting / docs (2):
- `dc20405` `style(format): apply clang-format and gersemi to Phase 2 UI sources` — initial pass on the new C++ files.
- `a00a6aa` `docs(readme): document contributor formatter prerequisites` — adds a "Prerequisites for contributors" section to README covering `clang-format` ≥ 16 and `gersemi`.

Clang-tidy workflow modernization (8):
- `d28b151` `ci(clang-tidy): drop -std=c99 extra-arg so C++ files get correct language flags`
- `6087b21` `ci(clang-tidy): use real build tree's compile_commands for correct C++/Qt flags`
- `4099995` `ci(clang-tidy): switch to reviewdog with github-pr-check reporter for ephemeral annotations`
- `c25e225` `ci(clang-tidy): use efm patterns since reviewdog lacks built-in clang-tidy parser`
- `daa91ca` `ci(clang-tidy): tee output and drop pipefail so clang-tidy diagnostics don't red-check the step`
- `39a0699` `ci(clang-tidy): split into capture + reviewdog steps to work around bash pipefail default`
- `ebaafbd` `ci(clang-tidy): suppress unknown-warning-option errors for GCC-only flags`
- `4742996` `ci(clang-tidy): track .clang-tidy config and disable insecureAPI.DeprecatedOrUnsafeBufferHandling check` — `.clang-tidy` was gitignored and never committed; CI had been using clang-tidy defaults.

Lint fixes (1):
- `abc1559` `fix(lint): address clang-tidy diagnostics in Phase 2 UI sources` — with the real config active, clang-tidy found 15 warnings on added lines. Fixed: 4 `misc-const-correctness`, 1 `bugprone-branch-clone` (consolidated two identical branches in `load_config_from_disk`), 1 `readability-named-parameter`. Suppressed inline with NOLINT: `readability-redundant-access-specifiers`. Disabled globally in `.clang-tidy`: `readability-implicit-bool-conversion`.

Post-test-round cosmetic fixes (1):
- `0f41104` `fix(ui): quote multi-word locale values and widen spin boxes + dialog` — first manual-test round surfaced that OBS's locale parser truncates at whitespace unless values are quoted. Also QSpinBox arrows were clipping values like "8000" and "10". Fixed via quoted locale values + `setMinimumWidth(100)` on spin boxes + `setMinimumWidth(420)` on the dialog.

**New files**
- `src/frontend-wire.{h,cpp}` — Tools menu registration, config JSON load/save, singleton access.
- `src/radio-output-config-dialog.{hpp,cpp}` — `RadioOutputConfigDialog` QDialog subclass.

**Non-obvious design calls**
- **Module-global config, not per-output config.** The OBS output is instantiated lazily when the user clicks Start (§B.2); config lives independently in `frontend-wire`. This lets the config be edited without touching a running output.
- **Save on OK only.** Dialog mutates `g_config` directly on OK; Cancel leaves it untouched. No intermediate persistence or undo stack needed.
- **`save_config_to_disk()` also called in `frontend_wire_unload()`** — belt-and-suspenders.
- **`CMakePresets.json` "template" preset owns the config toggles.** Keeps every build tree consistent.
- **reviewdog over cpp-linter.** Ephemeral check annotations instead of persistent review comments.
- **Two-step clang-tidy invocation.** GitHub Actions' bash shebang hardcodes `-e -o pipefail`; splitting into capture-then-process avoids the pipe issue.
- **`.clang-tidy` now tracked.** Before this PR the file was locally present but gitignored — CI ran default checks.
- **Multi-word locale values must be quoted.** Surfaced during manual testing (0f41104). Convention followed by obs-studio itself.

**Residual clang-tidy warnings on pre-existing code** (not annotated; `-filter-mode=added` scopes to added lines):
- 7× `bugprone-implicit-widening-of-multiplication-result` in `radio-output.c` (Phase 1 MP3 math)
- 1× `performance-enum-size` on `radio_state_t` in `radio-output.h:19` (Phase 1 enum)

**Deferred to later items in §B**
- Dock widget with Start/Stop + status (§B.2)
- Auto-start/stop with OBS streaming events (§B.3)
- Retire `scripts/radio-test.lua` as primary driver (§B.4)

**Test plan**

- [x] CI passes on the latest commit (`0f41104`) — all 11 checks green

### Setup

```bash
cd ~/Code/Tech-Noid-Systems/obs-radio-output
git fetch origin feat/ui-config-dialog
git checkout feat/ui-config-dialog
rm -rf build_macos
cmake --preset macos
./build-and-install-macos.sh
```

⌘Q OBS, relaunch.

#### Test 7 — Tools menu registration ✅ PASS

1. Click **Tools** in the OBS menu bar.
2. Look for **Radio Output…** item.

**Pass:**
- [x] Item appears in the Tools menu *(note: shown as "Radio" before the 0f41104 cosmetic fix; rebuild confirms full "Radio Output…" label)*

#### Test 8 — Dialog opens with defaults (fresh install) ✅ PASS

1. Ensure `~/Library/Application Support/obs-studio/plugin_config/obs-radio-output/config.json` does NOT exist (delete if it does).
2. ⌘Q OBS, relaunch.
3. Click **Tools → Radio Output…**

**Pass:**
- [x] Dialog opens *(title was "Radio" before 0f41104; now "Radio Output Configuration")*
- [x] Host defaults to `localhost`, Port `8000`, Mount `/stream`, Password empty
- [x] Codec `MP3`, Bitrate `128 kbps`
- [x] Reconnect enabled checked, Delay `5`, Max `10`
- [x] Start-with-streaming checkbox unchecked *(label was "Start/stop" before 0f41104; now full "Start/stop radio with OBS streaming")*
- [x] OK and Cancel buttons present

#### Test 9 — Settings persistence round-trip ✅ PASS

1. Click Tools → Radio Output…
2. Change values, click OK
3. Verify `config.json` was written
4. Re-open dialog

**Pass:**
- [x] `config.json` exists and contains all edited values
- [x] Re-opened dialog shows the edited values (not defaults)

#### Test 10 — Cancel discards ✅ PASS

**Pass:**
- [x] Edited value reverts after Cancel
- [x] `config.json` mtime unchanged

#### Test 11 — Persistence across OBS restart ✅ PASS

**Pass:**
- [x] All values from before the restart are present

#### Test 12 — Existing Lua-driven streaming still works (regression) ✅ PASS

1. Load `scripts/radio-test.lua` via Tools → Scripts.
2. Click Start in the Lua panel.

**Pass:**
- [x] Audio still streams to Icecast

### Summary

**All 6/6 manual tests PASS.** Tests 7 and 8 verified the cosmetic fix from `0f41104` alongside the original acceptance criteria. Ready to merge.

### If a test fails
- OBS log: `~/Library/Application Support/obs-studio/logs/*.txt`
- Config file: `~/Library/Application\ Support/obs-studio/plugin_config/obs-radio-output/config.json`
- Note which test + step, share the log and config contents

