### PR TITLE
feat(ui): persistent dock widget with Start/Stop and connection status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ target_sources(
     src/frontend-wire.h
     src/radio-output-config-dialog.cpp
     src/radio-output-config-dialog.hpp
+    src/radio-output-dock.cpp
+    src/radio-output-dock.hpp
 )
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -22,3 +22,13 @@ RadioOutput.StartWithStreaming="Start/stop radio with OBS streaming"
 
 RadioOutput.Menu.OpenConfig="Radio Output…"
 RadioOutput.Config.Title="Radio Output Configuration"
+
+RadioOutput.Dock.Name="Radio Output"
+RadioOutput.Dock.Start="Start"
+RadioOutput.Dock.Stop="Stop"
+
+RadioOutput.State.Disconnected="Disconnected"
+RadioOutput.State.Connecting="Connecting…"
+RadioOutput.State.Connected="Live"
+RadioOutput.State.Reconnecting="Reconnecting…"
+RadioOutput.State.Error="Error"

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -184,10 +184,20 @@ extern "C" bool frontend_wire_start_output(void)
 
 extern "C" void frontend_wire_stop_output(void)
 {
-	if (!g_active_output_handle)
-		return;
+	/* Stop whichever radio output is currently live, regardless of who
+	 * created it (dock Start button vs. scripts/radio-test.lua).  The
+	 * dock behaves as a universal "stop the running broadcast" remote
+	 * until the Lua driver is retired in §B.4. */
+	struct radio_output *ctx = radio_output_get_active();
+	if (ctx && ctx->output)
+		obs_output_stop(ctx->output);
 
-	obs_output_stop(g_active_output_handle);
-	obs_output_release(g_active_output_handle);
-	g_active_output_handle = nullptr;
+	/* Only release the obs_output_t if we own it — i.e. the dock
+	 * started the broadcast via frontend_wire_start_output().  When Lua
+	 * created the output, Lua owns the ref; calling release here would
+	 * double-decrement and crash on Lua's own release. */
+	if (g_active_output_handle) {
+		obs_output_release(g_active_output_handle);
+		g_active_output_handle = nullptr;
+	}
 }

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -31,6 +31,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <string>
 
 #include "radio-output-config-dialog.hpp"
+#include "radio-output-dock.hpp"
 #include "radio-output.h"
 
 namespace {
@@ -39,6 +40,11 @@ constexpr const char *kConfigFileName = "config.json";
 
 /* Module-global config.  Owned by this translation unit. */
 obs_data_t *g_config = nullptr;
+
+/* Module-global active obs_output_t handle.  Populated by
+ * frontend_wire_start_output, released by frontend_wire_stop_output.
+ * nullptr when nothing is running. */
+obs_output_t *g_active_output_handle = nullptr;
 
 std::string config_file_path()
 {
@@ -126,10 +132,16 @@ extern "C" void frontend_wire_load(void)
 
 	obs_frontend_add_tools_menu_item(obs_module_text("RadioOutput.Menu.OpenConfig"), on_tools_menu_clicked,
 					 nullptr);
+
+	/* Register the persistent dock.  OBS takes ownership of the widget
+	 * and keeps it alive for the lifetime of the frontend. */
+	auto *dock = new RadioOutputDock();
+	obs_frontend_add_dock_by_id("obs-radio-output-dock", obs_module_text("RadioOutput.Dock.Name"), dock);
 }
 
 extern "C" void frontend_wire_unload(void)
 {
+	frontend_wire_stop_output();
 	save_config_to_disk();
 
 	if (g_config) {
@@ -141,4 +153,41 @@ extern "C" void frontend_wire_unload(void)
 extern "C" obs_data_t *frontend_wire_get_config(void)
 {
 	return g_config;
+}
+
+extern "C" bool frontend_wire_start_output(void)
+{
+	if (g_active_output_handle) {
+		obs_log(LOG_INFO, "[frontend-wire] output already running; start request ignored");
+		return true;
+	}
+	if (!g_config) {
+		obs_log(LOG_ERROR, "[frontend-wire] cannot start output: config not loaded");
+		return false;
+	}
+
+	g_active_output_handle = obs_output_create("radio_output", "radio_output_inst", g_config, nullptr);
+	if (!g_active_output_handle) {
+		obs_log(LOG_ERROR, "[frontend-wire] obs_output_create failed");
+		return false;
+	}
+
+	if (!obs_output_start(g_active_output_handle)) {
+		obs_log(LOG_ERROR, "[frontend-wire] obs_output_start failed");
+		obs_output_release(g_active_output_handle);
+		g_active_output_handle = nullptr;
+		return false;
+	}
+
+	return true;
+}
+
+extern "C" void frontend_wire_stop_output(void)
+{
+	if (!g_active_output_handle)
+		return;
+
+	obs_output_stop(g_active_output_handle);
+	obs_output_release(g_active_output_handle);
+	g_active_output_handle = nullptr;
 }

--- a/src/frontend-wire.h
+++ b/src/frontend-wire.h
@@ -48,6 +48,25 @@ void frontend_wire_unload(void);
  */
 obs_data_t *frontend_wire_get_config(void);
 
+/*
+ * Create a fresh radio_output using the current config and call
+ * obs_output_start() on it.  If an output is already running, this is a
+ * no-op (returns true).  Returns true on success, false if the output
+ * couldn't be created or started.
+ *
+ * The created obs_output_t is owned by this module for the lifetime of
+ * the broadcast and released by frontend_wire_stop_output().  Callers
+ * should NOT release the returned handle — this function doesn't return
+ * one.
+ */
+bool frontend_wire_start_output(void);
+
+/*
+ * Stop the currently running output (if any) and release its handle.
+ * Idempotent: safe to call when nothing is running.
+ */
+void frontend_wire_stop_output(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/radio-output-dock.cpp
+++ b/src/radio-output-dock.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include "radio-output-dock.hpp"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include <obs-module.h>
+#include <pthread.h>
+
+#include "frontend-wire.h"
+#include "radio-output.h"
+
+namespace {
+
+/* Poll interval for the connection-state label.  500 ms keeps the UI
+ * responsive without spinning the CPU; it's also short enough that state
+ * transitions feel instant to the user. */
+constexpr int kPollIntervalMs = 500;
+
+struct StateDisplay {
+	const char *locale_key;
+	const char *stylesheet_color;
+};
+
+StateDisplay displayFor(radio_state_t state)
+{
+	switch (state) {
+	case RADIO_STATE_CONNECTING:
+		return {"RadioOutput.State.Connecting", "#d6a100"}; /* amber */
+	case RADIO_STATE_CONNECTED:
+		return {"RadioOutput.State.Connected", "#2ca14b"}; /* green */
+	case RADIO_STATE_RECONNECTING:
+		return {"RadioOutput.State.Reconnecting", "#d17d00"}; /* orange */
+	case RADIO_STATE_ERROR:
+		return {"RadioOutput.State.Error", "#c0392b"}; /* red */
+	case RADIO_STATE_DISCONNECTED:
+	default:
+		return {"RadioOutput.State.Disconnected", "#888888"}; /* grey */
+	}
+}
+
+} // namespace
+
+RadioOutputDock::RadioOutputDock(QWidget *parent) : QFrame(parent)
+{
+	setFrameShape(QFrame::NoFrame);
+
+	status_ = new QLabel(obs_module_text("RadioOutput.State.Disconnected"), this);
+	QFont font = status_->font();
+	font.setPointSize(font.pointSize() + 2);
+	font.setBold(true);
+	status_->setFont(font);
+	status_->setAlignment(Qt::AlignCenter);
+
+	start_ = new QPushButton(obs_module_text("RadioOutput.Dock.Start"), this);
+	stop_ = new QPushButton(obs_module_text("RadioOutput.Dock.Stop"), this);
+	stop_->setEnabled(false);
+
+	connect(start_, &QPushButton::clicked, this, &RadioOutputDock::onStart);
+	connect(stop_, &QPushButton::clicked, this, &RadioOutputDock::onStop);
+
+	auto *buttons = new QHBoxLayout;
+	buttons->addWidget(start_);
+	buttons->addWidget(stop_);
+
+	auto *layout = new QVBoxLayout(this);
+	layout->addWidget(status_);
+	layout->addLayout(buttons);
+	layout->addStretch(1); /* Reserved vertical space for §F (Now Playing) and §G (listener count). */
+
+	poll_ = new QTimer(this);
+	poll_->setInterval(kPollIntervalMs);
+	connect(poll_, &QTimer::timeout, this, &RadioOutputDock::pollState);
+	poll_->start();
+}
+
+void RadioOutputDock::onStart()
+{
+	frontend_wire_start_output();
+	/* State update happens via pollState() on next tick, so the button
+	 * enabled-state flips then rather than optimistically here. */
+}
+
+void RadioOutputDock::onStop()
+{
+	frontend_wire_stop_output();
+}
+
+void RadioOutputDock::pollState()
+{
+	struct radio_output *ctx = radio_output_get_active();
+	radio_state_t state = RADIO_STATE_DISCONNECTED;
+	if (ctx) {
+		pthread_mutex_lock(&ctx->state_mutex);
+		state = ctx->state;
+		pthread_mutex_unlock(&ctx->state_mutex);
+	}
+
+	const StateDisplay disp = displayFor(state);
+	status_->setText(obs_module_text(disp.locale_key));
+	status_->setStyleSheet(QString("QLabel { color: %1; }").arg(disp.stylesheet_color));
+
+	const bool running = (state == RADIO_STATE_CONNECTING || state == RADIO_STATE_CONNECTED ||
+			      state == RADIO_STATE_RECONNECTING);
+	start_->setEnabled(!running);
+	stop_->setEnabled(running || state == RADIO_STATE_ERROR);
+}

--- a/src/radio-output-dock.hpp
+++ b/src/radio-output-dock.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#pragma once
+
+#include <QFrame>
+#include <QLabel>
+#include <QPushButton>
+#include <QTimer>
+
+/*
+ * Persistent OBS dock widget with connection status and Start / Stop
+ * buttons.  Registered by frontend-wire.cpp via
+ * obs_frontend_add_dock_by_id().
+ *
+ * Lifetime: owned by OBS after registration (for the process lifetime).
+ * State polled every 500 ms via QTimer from the main thread.
+ */
+class RadioOutputDock : public QFrame {
+	Q_OBJECT
+
+public:
+	explicit RadioOutputDock(QWidget *parent = nullptr);
+
+private slots:
+	void onStart();
+	void onStop();
+	void pollState();
+
+private: // NOLINT(readability-redundant-access-specifiers) — visually separate Qt slots from members
+	QLabel *status_;
+	QPushButton *start_;
+	QPushButton *stop_;
+	QTimer *poll_;
+};

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -4,6 +4,27 @@
 #include "reconnect.h"
 #include <plugin-support.h>
 
+/*
+ * Module-global pointer to the currently instantiated output, for the dock
+ * widget (src/radio-output-dock.cpp) and frontend event handler (§B.3) to
+ * read connection state from.  Assigned in radio_output_create, cleared in
+ * radio_output_destroy.  Read-only access elsewhere; callers must hold
+ * context->state_mutex to read the state field safely.
+ *
+ * Pointer reads/writes are atomic at the machine level on all supported
+ * platforms, and all writers run on the OBS main thread (create/destroy
+ * callbacks), so no explicit synchronization is needed around the pointer
+ * itself.  The lifetime race — destroy clearing the pointer while a reader
+ * dereferences it — is precluded because the dock (the only reader today)
+ * runs its QTimer on the main thread too, serialized with destroy.
+ */
+static struct radio_output *g_active_output = NULL;
+
+struct radio_output *radio_output_get_active(void)
+{
+	return g_active_output;
+}
+
 static const char *radio_output_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
@@ -43,6 +64,7 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 #endif
 
 	radio_output_update(context, settings);
+	g_active_output = context;
 	return context;
 }
 
@@ -125,6 +147,13 @@ static void radio_output_destroy(void *data)
 		return;
 
 	radio_output_teardown(context);
+
+	/* Clear the module-global pointer only if it still points at us.  If a
+	 * second output was created in parallel (unlikely but possible via Lua
+	 * during transition), g_active_output tracks whichever was created
+	 * last; don't clobber it. */
+	if (g_active_output == context)
+		g_active_output = NULL;
 
 #ifdef HAVE_LIBSHOUT
 	shout_shutdown();

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -13,6 +13,10 @@
 #include <lame/lame.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RADIO_OUTPUT_RECONNECT_DELAY_MS  5000
 #define RADIO_OUTPUT_RECONNECT_MAX       10
 
@@ -119,3 +123,7 @@ extern struct obs_output_info radio_output_info;
  * radio-output.c for the lifetime guarantee.
  */
 struct radio_output *radio_output_get_active(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -110,3 +110,12 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout);
 #define SETTING_START_WITH_STREAMING "start_with_streaming"
 
 extern struct obs_output_info radio_output_info;
+
+/*
+ * Returns the currently instantiated output's context, or NULL if none is
+ * active.  Intended for the dock widget and frontend event handler to
+ * read connection state.  Callers that read state fields must acquire
+ * context->state_mutex — see radio_output_get_active() comment in
+ * radio-output.c for the lifetime guarantee.
+ */
+struct radio_output *radio_output_get_active(void);


### PR DESCRIPTION
**Summary**
- Second of four Phase 2 §B PRs. Adds a **Radio Output dock widget** — persistent, always-visible panel with connection-state indicator and Start / Stop buttons. BUTT-style ergonomics: one click to go live, at-a-glance status, no modal dialog in the hot path.
- Registered via `obs_frontend_add_dock_by_id("obs-radio-output-dock", ...)`. Appears under **View → Docks**; drag into OBS's main window, float, or stash anywhere.
- Introduces the **module-global `g_active_output`** pointer (spec: `implementation.md` §B) that lets the dock (and the upcoming §B.3 frontend-event handler) read connection state without duplicating output instantiation logic.
- Centralizes the output lifecycle via two new `frontend-wire` helpers — `frontend_wire_start_output()` / `frontend_wire_stop_output()` — so the dock's buttons and §B.3's streaming-event callback share identical create / start / stop / release paths.

**New files**
- `src/radio-output-dock.{hpp,cpp}` — `RadioOutputDock : public QFrame`, QTimer-polled (500 ms) status label + Start / Stop buttons with color-coded state.

**Changes to existing files**
- `src/radio-output.c` + `.h` — adds static `g_active_output` pointer and `radio_output_get_active()` accessor. Assigned in `create`, cleared in `destroy` (only if still pointing at the instance being destroyed, to handle the rare transition case of two outputs in flight).
- `src/frontend-wire.{cpp,h}` — new `frontend_wire_start_output()` / `_stop_output()` that encapsulate `obs_output_create` + `obs_output_start` + `obs_output_release`. `frontend_wire_unload()` now also stops the output as cleanup.
- `src/frontend-wire.cpp` — registers the dock widget in `frontend_wire_load()` via `obs_frontend_add_dock_by_id()`.
- `data/locale/en-US.ini` — dock name, button labels, 5 state labels.
- `CMakeLists.txt` — adds the two new sources to `target_sources`.

**State → label + color mapping**
| State | Label | Color |
|---|---|---|
| `DISCONNECTED` | "Disconnected" | grey |
| `CONNECTING` | "Connecting…" | amber |
| `CONNECTED` | "Live" | green |
| `RECONNECTING` | "Reconnecting…" | orange |
| `ERROR` | "Error" | red |

Button enabled-state follows the connection state — Start disabled while running, Stop disabled while fully disconnected (but enabled in ERROR so the user can clear the error cleanly).

**Non-obvious design calls**
- **QTimer polling (500 ms), not signal-based updates.** The output lives in C land and changes state from multiple worker threads; signals would require thread-safe Qt wiring for every state transition. A 500 ms poll is the simpler, more robust solution, and the UX cost is negligible (500 ms is imperceptible for connection-state feedback). Spec notes this trade-off.
- **`radio_output_get_active()` returns a raw pointer without locking.** Reads and writes of the pointer are naturally atomic on all supported platforms. The only lifetime race — destroy clearing the pointer while the dock reads it — is precluded because both the dock's QTimer callback and the output's destroy callback run on OBS's main thread.
- **No optimistic button state flip on click.** `onStart()` just calls `frontend_wire_start_output()`; the next `pollState()` tick (≤ 500 ms later) flips the buttons. Simpler than tracking an intermediate "waiting for start" state and avoids button flicker if the start fails.
- **Dock widget uses `QFrame`, not `QWidget`.** Gives us a default visual boundary when floated or docked at edges. Set to `NoFrame` currently since OBS docks already have chrome, but `QFrame` keeps styling hooks available.

**Deferred to later items in §B**
- **§B.3 (auto-start with OBS streaming):** the `frontend_wire_start_output()` / `_stop_output()` helpers this PR adds are exactly what the event callback in §B.3 will call. Next PR is a small wiring change.
- **§B.4 (retire `scripts/radio-test.lua`):** docs-only cleanup.

Future slots reserved in the dock's `QVBoxLayout`: the `addStretch(1)` at the bottom is holding vertical space for §F (Now Playing) and §G (listener count) to land cleanly without resizing the dock.

**Test plan**

- [ ] CI passes (clang-format, gersemi, build × 4 platforms, CodeQL, Clang-Tidy via reviewdog, check-commits)

### Setup

```bash
cd ~/Code/Tech-Noid-Systems/obs-radio-output
git fetch origin feat/ui-dock-widget
git checkout feat/ui-dock-widget
./build-and-install-macos.sh
```

⌘Q OBS, relaunch. Start the test Icecast:

```bash
docker rm -f icecast 2>/dev/null
docker run -d --name icecast -p 8000:8000 moul/icecast
```

Tail the log:

```bash
tail -F ~/Library/Application\ Support/obs-studio/logs/*.txt
```

#### Test 13 — Dock registration and placement

1. Open **View → Docks**.
2. Find **Radio Output** in the list.
3. Toggle it on.
4. Drag the dock into the main OBS window (or leave floating).

**Pass:**
- [x] "Radio Output" entry exists under View → Docks
- [x] Dock displays: centered status label ("Disconnected" in grey) + Start button (enabled) + Stop button (disabled)
- [x] Dock can be dragged into any OBS dock area; survives OBS restart with layout preserved

#### Test 14 — Start / Stop happy path from dock

1. **Tools → Radio Output…** confirm settings point at `localhost:8000/stream` with password `hackme`. OK.
2. In the dock, click **Start**.

**Pass:**
- [x] Status label transitions: "Disconnected" → "Connecting…" (amber) → "Live" (green) within ~1 s
- [x] Start button disables; Stop button enables
- [x] VLC on `http://localhost:8000/stream` plays audio
- [x] Log shows `Connected to localhost:8000/stream` and `MP3 send thread started`

3. Click **Stop**.

**Pass:**
- [x] Status returns to "Disconnected" (grey) within ~500 ms
- [x] Start enables, Stop disables
- [x] Log shows `Disconnected from localhost:8000/stream` (all three PR #21 stop-path log lines fire)
- [x] VLC stream ends cleanly

#### Test 15 — Error-state recovery from dock

1. Click Start; confirm "Live".
2. `docker stop icecast`
3. Watch the dock: status should transition through "Reconnecting…" (orange) as the retry cycles run; after max-retries, status should show "Error" (red).

**Pass:**
- [x] Reconnecting label appears with at least one retry attempt logged
- [x] After max retries: status shows "Error"; Stop button enabled
- [x] Click Stop while in Error state; status returns to "Disconnected" cleanly (PR #21 teardown path fires)

#### Test 16 — Coexistence with Lua test script (regression)

1. Load `scripts/radio-test.lua` via Tools → Scripts.
2. Click Start in the Lua panel.

**Pass:**
- [x] Audio streams via Lua-created output
- [x] Dock reflects the Lua output's state (since `g_active_output` tracks whichever instance was last created)
- [x] Dock Stop button stops the Lua-created output cleanly *(fixed in commit 52c554c — stops via back-pointer on the struct rather than the handle, since Lua owns the obs_output_t it created)*

#### Test 17 — Module unload cleanup

1. Start the output from the dock. Confirm "Live".
2. ⌘Q OBS (full quit).

**Pass:**
- [x] OBS quits cleanly within ~1 s (no beachball); `frontend_wire_unload` calls `frontend_wire_stop_output` so the active output is torn down before the module exits
- [x] No crash reports: `ls ~/Library/Logs/DiagnosticReports/ | grep -i obs` returns empty

### If a test fails
- OBS log: `~/Library/Application Support/obs-studio/logs/*.txt`
- Config file: `~/Library/Application\ Support/obs-studio/plugin_config/obs-radio-output/config.json`
- Stack sample during any stuck state: `sample OBS 5 -file /tmp/obs-hang.txt`
- Note which test + step, share the log and stack trace
