### PR TITLE
feat(ui): tie radio start/stop to OBS streaming events

### DIFF
--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -140,14 +140,6 @@ void on_tools_menu_clicked(void * /*priv*/)
  */
 void on_frontend_event(enum obs_frontend_event event, void * /*priv*/)
 {
-	/* TEMP DEBUG: fires for every streaming-related event, showing the
-	 * exact config state the handler sees.  Revert before merge. */
-	if (event == OBS_FRONTEND_EVENT_STREAMING_STARTING || event == OBS_FRONTEND_EVENT_STREAMING_STARTED ||
-	    event == OBS_FRONTEND_EVENT_STREAMING_STOPPING || event == OBS_FRONTEND_EVENT_STREAMING_STOPPED) {
-		obs_log(LOG_INFO, "[frontend-wire] DBG event=%d config=%p start_with=%d", (int)event, (void *)g_config,
-			g_config ? (int)obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING) : -1);
-	}
-
 	if (!g_config)
 		return;
 	if (!obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING))

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -140,6 +140,14 @@ void on_tools_menu_clicked(void * /*priv*/)
  */
 void on_frontend_event(enum obs_frontend_event event, void * /*priv*/)
 {
+	/* TEMP DEBUG: fires for every streaming-related event, showing the
+	 * exact config state the handler sees.  Revert before merge. */
+	if (event == OBS_FRONTEND_EVENT_STREAMING_STARTING || event == OBS_FRONTEND_EVENT_STREAMING_STARTED ||
+	    event == OBS_FRONTEND_EVENT_STREAMING_STOPPING || event == OBS_FRONTEND_EVENT_STREAMING_STOPPED) {
+		obs_log(LOG_INFO, "[frontend-wire] DBG event=%d config=%p start_with=%d", (int)event, (void *)g_config,
+			g_config ? (int)obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING) : -1);
+	}
+
 	if (!g_config)
 		return;
 	if (!obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING))

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -124,6 +124,43 @@ void on_tools_menu_clicked(void * /*priv*/)
 		save_config_to_disk();
 }
 
+/*
+ * Tie radio start/stop to OBS's streaming Start / Stop events when the
+ * user has opted in via the "Start/stop radio with OBS streaming"
+ * checkbox.  Opt-in is checked live (from g_config) at event time, so
+ * toggling the setting takes effect on the NEXT transition without
+ * requiring re-registration of the callback.
+ *
+ * Radio failures never block video: frontend_wire_start_output() logs
+ * and returns false on its own, we just surface the warning.
+ *
+ * Recording events (OBS_FRONTEND_EVENT_RECORDING_STARTING/STOPPING)
+ * are deliberately not handled here — extending to recording is a
+ * separate setting + additional case labels in a future phase.
+ */
+void on_frontend_event(enum obs_frontend_event event, void * /*priv*/)
+{
+	if (!g_config)
+		return;
+	if (!obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING))
+		return;
+
+	switch (event) {
+	case OBS_FRONTEND_EVENT_STREAMING_STARTING:
+		obs_log(LOG_INFO, "[frontend-wire] OBS streaming starting — auto-starting radio output");
+		if (!frontend_wire_start_output())
+			obs_log(LOG_WARNING,
+				"[frontend-wire] radio auto-start failed; OBS video streaming continues unaffected");
+		break;
+	case OBS_FRONTEND_EVENT_STREAMING_STOPPING:
+		obs_log(LOG_INFO, "[frontend-wire] OBS streaming stopping — auto-stopping radio output");
+		frontend_wire_stop_output();
+		break;
+	default:
+		break;
+	}
+}
+
 } // namespace
 
 extern "C" void frontend_wire_load(void)
@@ -137,10 +174,16 @@ extern "C" void frontend_wire_load(void)
 	 * and keeps it alive for the lifetime of the frontend. */
 	auto *dock = new RadioOutputDock();
 	obs_frontend_add_dock_by_id("obs-radio-output-dock", obs_module_text("RadioOutput.Dock.Name"), dock);
+
+	/* Tie radio start/stop to OBS streaming events.  The callback checks
+	 * SETTING_START_WITH_STREAMING live, so the opt-in toggle works
+	 * without needing to re-register. */
+	obs_frontend_add_event_callback(on_frontend_event, nullptr);
 }
 
 extern "C" void frontend_wire_unload(void)
 {
+	obs_frontend_remove_event_callback(on_frontend_event, nullptr);
 	frontend_wire_stop_output();
 	save_config_to_disk();
 


### PR DESCRIPTION
**Summary**
- Third of four Phase 2 §B PRs. Wires the **Start/stop radio with OBS streaming** checkbox (landed in PR #22) into an actual `obs_frontend_add_event_callback` handler. When the user enables the checkbox and clicks OBS's main Start Streaming button, the radio output auto-starts. When video streaming stops, radio auto-stops.
- Dock's Start / Stop buttons remain fully functional regardless of the setting — this is an additive auto-trigger, not a replacement. Manual control always works.
- 43 lines of code in one file. The heavy lifting (output lifecycle: `frontend_wire_start_output()` / `_stop_output()`) already landed in PR #24; this PR only adds the event handler that invokes them.

**Design calls (locked in during planning)**
- **Opt-in via `SETTING_START_WITH_STREAMING`** — the handler reads the setting live from `g_config`, so toggling the checkbox takes effect on the next streaming-event transition without re-registering the callback.
- **Radio failures never block video** — `frontend_wire_start_output()` handles its own errors and returns false; the callback logs a warning and lets OBS proceed with video streaming.
- **Streaming events only, recording deferred** — handler is a `switch`/`case` over event type; extending to `OBS_FRONTEND_EVENT_RECORDING_STARTING/STOPPING` in a future phase is trivial (new setting + added case labels).
- **No retroactive start** — callback fires on event transitions only; enabling the checkbox while OBS is already streaming video won't start radio mid-stream. Dock Start remains available for that flow.

**Files touched**
- `src/frontend-wire.cpp` — `on_frontend_event()` handler added; `obs_frontend_add_event_callback()` in load; `obs_frontend_remove_event_callback()` in unload.

**Test plan**

- [x] CI passes (clang-format, gersemi, build × 4 platforms, CodeQL, Clang-Tidy via reviewdog, check-commits)

### Setup

```bash
cd ~/Code/Tech-Noid-Systems/obs-radio-output
git fetch origin feat/ui-tie-to-streaming
git checkout feat/ui-tie-to-streaming
./build-and-install-macos.sh
```

⌘Q OBS, relaunch. Start the test Icecast:

```bash
docker rm -f icecast 2>/dev/null
docker run -d --name icecast -p 8000:8000 moul/icecast
```

Tail the log:

```bash
tail -F ~/Library/Application\ Support/obs-studio/logs/*.txt
```

#### Test 18 — Checkbox OFF: OBS streaming doesn't touch radio

1. **Tools → Radio Output…** → uncheck "Start/stop radio with OBS streaming" → OK.
2. Configure an OBS RTMP service (any — doesn't need to actually broadcast; Twitch with a fake key works). Don't click Start Streaming in OBS yet.
3. In the dock, click **Start** — radio goes Live manually.
4. In the OBS main window, click **Start Streaming** (video). Video goes live.
5. Click **Stop Streaming** (video). Video stops.

**Pass:**
- [x] When OBS video streaming starts, radio remains unchanged (stays Live since you manually started it)
- [x] When OBS video streaming stops, radio remains unchanged (stays Live)
- [x] No `OBS streaming starting — auto-starting radio output` log lines fire

Stop the radio manually via dock. Done.

#### Test 19 — Checkbox ON: OBS streaming auto-triggers radio

1. **Tools → Radio Output…** → check "Start/stop radio with OBS streaming" → OK.
2. Dock shows radio as "Disconnected".
3. Click OBS's **Start Streaming** button.

**Pass:**
- [x] Log shows `OBS streaming starting — auto-starting radio output`
- [x] Radio dock transitions Disconnected → Connecting… → Live within ~1 s
- [x] Both OBS video stream and radio audio are live in parallel
- [x] VLC on `http://localhost:8000/stream` plays audio

4. Click OBS's **Stop Streaming** button.

**Pass:**
- [x] Log shows `OBS streaming stopping — auto-stopping radio output`
- [x] Radio dock transitions to "Disconnected"
- [x] All three PR #21 stop-path log lines fire (`reconnect thread stopped`, `MP3 send thread stopped`, `Disconnected from …`)
- [x] VLC stream ends cleanly

#### Test 20 — Radio failure with checkbox ON doesn't block video ✅ PASS

1. **Tools → Radio Output…** → change Password to a WRONG value (e.g. `badpass`) → OK.
2. Ensure checkbox is still ON.
3. `docker ps` — confirm Icecast is running (we want Icecast available so the connection fails at auth, not transport).
4. Click OBS **Start Streaming**.

**Pass:**
- [x] Log shows `OBS streaming starting — auto-starting radio output`
- [x] Radio attempts to connect, fails auth, logs `radio auto-start failed; OBS video streaming continues unaffected`
- [x] OBS video streaming still goes live (the RTMP output isn't blocked by the radio failure)
- [x] Dock shows radio as "Error" or "Disconnected" (depending on reconnect setting)

5. Click OBS **Stop Streaming** — video stops cleanly; radio already in non-live state is a no-op.
6. Fix password back via Tools → Radio Output… for subsequent tests.

#### Test 21 — Manual radio Stop mid-video doesn't affect video ✅ PASS

1. Checkbox ON. Icecast running. Good password.
2. OBS **Start Streaming** → both video and radio go live.
3. While video is still streaming, click **Stop** in the radio dock.

**Pass:**
- [x] Radio stops (dock goes Disconnected)
- [x] OBS video keeps streaming (no interruption to the Twitch / RTMP side)
- [x] Log shows the radio stop sequence, no video-related errors

4. Click OBS **Stop Streaming** — video stops. Radio is already stopped; handler's `frontend_wire_stop_output` call is a no-op (state-guard idempotency from PR #21).

#### Test 22 — Checkbox toggle mid-session takes effect on next transition ✅ PASS

1. Checkbox OFF. Click OBS **Start Streaming**. Radio stays off.
2. While video is streaming, Tools → Radio Output… → check the box → OK.

**Pass:**
- [x] Radio does NOT retroactively start (design call: no retroactive trigger)

3. Click OBS **Stop Streaming** (video stops; radio stays off because it was never started).
4. Click OBS **Start Streaming** again.

**Pass:**
- [x] This time, the radio auto-starts via the event callback

### If a test fails
- OBS log: `~/Library/Application Support/obs-studio/logs/*.txt`
- Config file: `~/Library/Application Support/obs-studio/plugin_config/obs-radio-output/config.json` — verify `"start_with_streaming"` value
- Note which test + step, share the log

Closes #54.



