### PR TITLE
chore(issues): add bug-report + feature-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly.
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug.  Fill in what you know — even partial information helps a lot.
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: Shown in the OBS log at startup — `[obs-radio-output] plugin loaded successfully (version X.Y.Z)`.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: obs-version
+    attributes:
+      label: OBS Studio version
+      description: Help → About, or the title bar on macOS.
+      placeholder: "31.1.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x86_64)
+        - Linux (aarch64)
+        - Windows (x64)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: server
+    attributes:
+      label: Icecast / SHOUTcast server
+      description: Which server are you streaming to?
+      options:
+        - Local Icecast (moul/icecast Docker image)
+        - Self-hosted Icecast (other)
+        - AzuraCast
+        - Shoutcast
+        - Hosted service (specify in the description)
+        - Other / unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. Include what you were trying to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps that trigger the bug, starting from a freshly-launched OBS.
+      placeholder: |
+        1. Open OBS and load `scripts/radio-test.lua` via Tools → Scripts
+        2. Click Start Radio Output
+        3. Stop the Icecast container with `docker stop icecast`
+        4. Wait for max-retries, then click Stop
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Paste the OBS log section around the bug.  Log location:
+        - macOS: `~/Library/Application Support/obs-studio/logs/`
+        - Linux: `~/.config/obs-studio/logs/`
+        - Windows: `%APPDATA%\obs-studio\logs\`
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, `docker logs icecast` output, crash dumps (`~/Library/Logs/DiagnosticReports/` on macOS), etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Build / install help
+    url: https://github.com/Tech-Noid-Systems/obs-radio-output#building-from-source
+    about: Per-platform setup instructions are in the README.
+  - name: OBS Studio general support
+    url: https://obsproject.com/kb/
+    about: For OBS Studio issues unrelated to this plugin, use the official OBS knowledge base / forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an enhancement or new capability.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.  Describing the underlying *problem* you're trying to solve is usually more useful than a specific solution — leave room for alternative approaches.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The real-world workflow or pain point.  (e.g. "I want to stream to two Icecast servers at once for redundancy" or "I want Now Playing metadata pulled from my DJ software automatically.")
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution (optional)
+      description: If you have a specific idea of how this should work, describe it here.  Otherwise leave blank and let the discussion find the approach.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Other ways you've thought about solving the same problem — including "do nothing" if that's reasonable.
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to contribute this?
+      description: Not a commitment — just helps plan.  Plugin is GPL-2.0+ and welcomes PRs.
+      options:
+        - I'd like to implement this myself (may need guidance)
+        - I could help test / review
+        - I'd rather just file it and let the maintainer decide
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, references, screenshots of similar features in other tools, etc.

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -124,6 +124,43 @@ void on_tools_menu_clicked(void * /*priv*/)
 		save_config_to_disk();
 }
 
+/*
+ * Tie radio start/stop to OBS's streaming Start / Stop events when the
+ * user has opted in via the "Start/stop radio with OBS streaming"
+ * checkbox.  Opt-in is checked live (from g_config) at event time, so
+ * toggling the setting takes effect on the NEXT transition without
+ * requiring re-registration of the callback.
+ *
+ * Radio failures never block video: frontend_wire_start_output() logs
+ * and returns false on its own, we just surface the warning.
+ *
+ * Recording events (OBS_FRONTEND_EVENT_RECORDING_STARTING/STOPPING)
+ * are deliberately not handled here — extending to recording is a
+ * separate setting + additional case labels in a future phase.
+ */
+void on_frontend_event(enum obs_frontend_event event, void * /*priv*/)
+{
+	if (!g_config)
+		return;
+	if (!obs_data_get_bool(g_config, SETTING_START_WITH_STREAMING))
+		return;
+
+	switch (event) {
+	case OBS_FRONTEND_EVENT_STREAMING_STARTING:
+		obs_log(LOG_INFO, "[frontend-wire] OBS streaming starting — auto-starting radio output");
+		if (!frontend_wire_start_output())
+			obs_log(LOG_WARNING,
+				"[frontend-wire] radio auto-start failed; OBS video streaming continues unaffected");
+		break;
+	case OBS_FRONTEND_EVENT_STREAMING_STOPPING:
+		obs_log(LOG_INFO, "[frontend-wire] OBS streaming stopping — auto-stopping radio output");
+		frontend_wire_stop_output();
+		break;
+	default:
+		break;
+	}
+}
+
 } // namespace
 
 extern "C" void frontend_wire_load(void)
@@ -137,10 +174,16 @@ extern "C" void frontend_wire_load(void)
 	 * and keeps it alive for the lifetime of the frontend. */
 	auto *dock = new RadioOutputDock();
 	obs_frontend_add_dock_by_id("obs-radio-output-dock", obs_module_text("RadioOutput.Dock.Name"), dock);
+
+	/* Tie radio start/stop to OBS streaming events.  The callback checks
+	 * SETTING_START_WITH_STREAMING live, so the opt-in toggle works
+	 * without needing to re-register. */
+	obs_frontend_add_event_callback(on_frontend_event, nullptr);
 }
 
 extern "C" void frontend_wire_unload(void)
 {
+	obs_frontend_remove_event_callback(on_frontend_event, nullptr);
 	frontend_wire_stop_output();
 	save_config_to_disk();
 


### PR DESCRIPTION
**Summary**
- Adds structured GitHub Issue templates (YAML form schemas) in `.github/ISSUE_TEMPLATE/`:
  - `bug_report.yml` — plugin version, OBS version, platform dropdown, server-type dropdown, steps to reproduce, expected vs actual, log output, additional context. All required fields enforced.
  - `feature_request.yml` — problem statement (what are you trying to do), optional proposed solution, alternatives, willingness to contribute.
  - `config.yml` — disables the blank-issue button and adds two "contact links" (README build instructions, OBS Studio general support) that show above the template picker.
- Auto-applied labels: `bug` + `triage` on bug reports, `enhancement` on feature requests.

**Why**
The README already points users to GitHub Issues for bug reports. Structured templates dramatically reduce back-and-forth asking for OBS version / platform / log excerpts — a single template ensures every bug comes in with enough info to act on.

**Goes with (not in this PR)**
- Labels: created via `gh label create` (`triage`, `phase-2`, `phase-3`, `dependencies`, `infra`, `ci`, `platform:{macos,linux,windows}`, `blocked`, `stretch`)
- Milestones: `Phase 2` (#1) and `Phase 3` (#2) created via `gh api`.
- Backlog issues: Phase 2 unstarted items (§B.4 through §I) and Phase 3 stretch goals will be backfilled as issues in a separate action (no repo change needed).

**Test plan**
- [ ] CI passes (no runtime change — just YAML files under `.github/`)
- [ ] After merge, Issues → New Issue shows the two form options with the contact links visible
- [ ] Clicking "Bug report" shows required fields matching the spec; submission auto-applies `bug` + `triage` labels