### PR TITLE
docs: retire scripts/radio-test.lua as primary driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,22 @@ cmake --install build_x64 --config RelWithDebInfo `
 
 ## Usage
 
-1. Open OBS Studio and go to **Settings → Stream**
-2. Select **Radio Output** from the Service dropdown
-3. Enter your Icecast server hostname, port, mount point, and password
-4. Select your audio codec and bitrate
-5. Click **Start Streaming**
+**One-time configuration:** **Tools → Radio Output…**. Enter your Icecast
+server hostname, port, mount point, and password. Pick codec (MP3 / Opus)
+and bitrate. Optionally enable "Start/stop radio with OBS streaming" if
+you want the radio to piggyback on OBS's main Start/Stop Streaming
+button. Click **OK** — settings persist across OBS restarts.
+
+**Running a broadcast:** open the **Radio Output** dock (**View → Docks
+→ Radio Output**). The dock shows connection status and has **Start** /
+**Stop** buttons. Click Start — the status label goes Disconnected →
+Connecting… → Live (color-coded). Click Stop to end the broadcast.
+
+**Tying to OBS streaming (optional):** if you enable the checkbox in the
+config dialog, clicking OBS's main **Start Streaming** button will also
+auto-start the radio; **Stop Streaming** auto-stops it. Radio failures
+never block OBS video streaming. The dock's Start/Stop buttons remain
+fully functional for manual control regardless of the checkbox.
 
 ## Reporting Bugs
 

--- a/scripts/radio-test.lua
+++ b/scripts/radio-test.lua
@@ -1,6 +1,17 @@
 -- radio-test.lua
--- Manual test harness for obs-radio-output.
--- Load via OBS Tools → Scripts, then use the Start / Stop buttons.
+--
+-- DEVELOPMENT AID ONLY — not the supported way to use this plugin.
+--
+-- The supported configuration path is Tools → Radio Output… (config dialog).
+-- The supported runtime-control path is the "Radio Output" dock
+-- (View → Docks → Radio Output, with Start / Stop buttons + connection
+-- status).  Both were added in Phase 2 Section B (PRs #22 and #24).
+--
+-- This script is retained as a minimal headless driver for quick
+-- regression testing from the command line / Lua console — it bypasses
+-- the config.json pipeline and hardcodes localhost:8000/stream settings.
+-- Use it when you want to sanity-check the output code path without
+-- exercising the UI.
 
 local obs = obslua
 


### PR DESCRIPTION
**Summary**
- Closes the last item in Phase 2 §B. Adds a banner comment to `scripts/radio-test.lua` marking it as a dev aid (not the supported usage path), and rewrites the README Usage section to match what actually ships now: Tools menu config dialog for setup, dock for Start/Stop, opt-in OBS-streaming tie-in.
- Keeps the Lua script. It's still a useful minimal headless driver for quick regression testing — just not the user-facing entry point anymore.

**Why**
The README's Usage section was factually wrong — it described a "Service dropdown" flow that doesn't exist. Phase 2 §B.1 (PR #22, Tools → Radio Output…) and §B.2 (PR #24, dock widget) replaced the Lua-driven flow with a proper UI. This PR aligns the docs.

Fixes #27.

**Files touched**
- `scripts/radio-test.lua` — top-of-file comment banner replaced; hardcoded localhost settings and functional code untouched.
- `README.md` — Usage section rewritten (Tools menu config + dock + optional streaming tie-in).

**Test plan**
- [ ] CI passes (no runtime change — just comment banner + docs)
- [ ] README renders correctly on GitHub (headings, emphasis, clickable links)

No manual behavior tests needed — the Lua script and plugin behavior are unchanged; only documentation.