### PR TITLE
feat(protocol): add Icecast / SHOUTcast v1 selector with dynamic mount visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,22 @@ cmake --install build_x64 --config RelWithDebInfo `
 
 ## Usage
 
-1. Open OBS Studio and go to **Settings → Stream**
-2. Select **Radio Output** from the Service dropdown
-3. Enter your Icecast server hostname, port, mount point, and password
-4. Select your audio codec and bitrate
-5. Click **Start Streaming**
+**One-time configuration:** **Tools → Radio Output…**. Enter your Icecast
+server hostname, port, mount point, and password. Pick codec (MP3 / Opus)
+and bitrate. Optionally enable "Start/stop radio with OBS streaming" if
+you want the radio to piggyback on OBS's main Start/Stop Streaming
+button. Click **OK** — settings persist across OBS restarts.
+
+**Running a broadcast:** open the **Radio Output** dock (**View → Docks
+→ Radio Output**). The dock shows connection status and has **Start** /
+**Stop** buttons. Click Start — the status label goes Disconnected →
+Connecting… → Live (color-coded). Click Stop to end the broadcast.
+
+**Tying to OBS streaming (optional):** if you enable the checkbox in the
+config dialog, clicking OBS's main **Start Streaming** button will also
+auto-start the radio; **Stop Streaming** auto-stops it. Radio failures
+never block OBS video streaming. The dock's Start/Stop buttons remain
+fully functional for manual control regardless of the checkbox.
 
 ## Reporting Bugs
 

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,6 +1,9 @@
 RadioOutput.Name="Radio Output (Icecast/SHOUTcast)"
 
 RadioOutput.Server.Group="Server"
+RadioOutput.Server.Protocol="Protocol"
+RadioOutput.Server.Protocol.Icecast="Icecast"
+RadioOutput.Server.Protocol.SHOUTcast="SHOUTcast (v1)"
 RadioOutput.Server.Host="Host"
 RadioOutput.Server.Port="Port"
 RadioOutput.Server.Mount="Mount Point"

--- a/scripts/radio-test.lua
+++ b/scripts/radio-test.lua
@@ -1,6 +1,17 @@
 -- radio-test.lua
--- Manual test harness for obs-radio-output.
--- Load via OBS Tools → Scripts, then use the Start / Stop buttons.
+--
+-- DEVELOPMENT AID ONLY — not the supported way to use this plugin.
+--
+-- The supported configuration path is Tools → Radio Output… (config dialog).
+-- The supported runtime-control path is the "Radio Output" dock
+-- (View → Docks → Radio Output, with Start / Stop buttons + connection
+-- status).  Both were added in Phase 2 Section B (PRs #22 and #24).
+--
+-- This script is retained as a minimal headless driver for quick
+-- regression testing from the command line / Lua console — it bypasses
+-- the config.json pipeline and hardcodes localhost:8000/stream settings.
+-- Use it when you want to sanity-check the output code path without
+-- exercising the UI.
 
 local obs = obslua
 

--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -81,6 +81,7 @@ void apply_defaults(obs_data_t *data)
 	obs_data_set_default_int(data, SETTING_RECONNECT_DELAY, 5);
 	obs_data_set_default_int(data, SETTING_RECONNECT_MAX, 10);
 	obs_data_set_default_bool(data, SETTING_START_WITH_STREAMING, false);
+	obs_data_set_default_int(data, SETTING_PROTOCOL, RADIO_PROTOCOL_ICECAST);
 }
 
 void load_config_from_disk()

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -33,11 +33,16 @@ namespace {
 /* Common internet-radio bitrates populated into the combo. */
 constexpr int kBitrates[] = {32, 48, 64, 96, 128, 192, 256, 320};
 
-QWidget *buildServerGroup(RadioOutputConfigDialog *parent, QLineEdit *&host, QSpinBox *&port, QLineEdit *&mount,
-			  QLineEdit *&password)
+QWidget *buildServerGroup(RadioOutputConfigDialog *parent, QComboBox *&protocol, QLineEdit *&host, QSpinBox *&port,
+			  QLineEdit *&mount, QLineEdit *&password, QFormLayout *&form_out, int &mount_row_index_out)
 {
 	auto *group = new QGroupBox(obs_module_text("RadioOutput.Server.Group"), parent);
 	auto *form = new QFormLayout(group);
+
+	protocol = new QComboBox(group);
+	protocol->addItem(obs_module_text("RadioOutput.Server.Protocol.Icecast"), RADIO_PROTOCOL_ICECAST);
+	protocol->addItem(obs_module_text("RadioOutput.Server.Protocol.SHOUTcast"), RADIO_PROTOCOL_SHOUTCAST);
+	form->addRow(obs_module_text("RadioOutput.Server.Protocol"), protocol);
 
 	host = new QLineEdit(group);
 	form->addRow(obs_module_text("RadioOutput.Server.Host"), host);
@@ -48,12 +53,14 @@ QWidget *buildServerGroup(RadioOutputConfigDialog *parent, QLineEdit *&host, QSp
 	form->addRow(obs_module_text("RadioOutput.Server.Port"), port);
 
 	mount = new QLineEdit(group);
+	mount_row_index_out = form->rowCount(); /* remember for setRowVisible() when protocol changes */
 	form->addRow(obs_module_text("RadioOutput.Server.Mount"), mount);
 
 	password = new QLineEdit(group);
 	password->setEchoMode(QLineEdit::Password);
 	form->addRow(obs_module_text("RadioOutput.Server.Password"), password);
 
+	form_out = form;
 	return group;
 }
 
@@ -127,7 +134,8 @@ RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *
 	setMinimumWidth(420);
 
 	auto *layout = new QVBoxLayout(this);
-	layout->addWidget(buildServerGroup(this, host_, port_, mount_, password_));
+	layout->addWidget(
+		buildServerGroup(this, protocol_, host_, port_, mount_, password_, server_form_, mount_row_index_));
 	layout->addWidget(buildAudioGroup(this, codec_, bitrate_));
 	layout->addWidget(buildReconnectGroup(this, reconnect_enabled_, reconnect_delay_, reconnect_max_));
 	layout->addWidget(buildIntegrationGroup(this, start_with_streaming_));
@@ -136,8 +144,11 @@ RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *
 	layout->addWidget(buttons);
 	connect(buttons, &QDialogButtonBox::accepted, this, &RadioOutputConfigDialog::onAccept);
 	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	connect(protocol_, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+		&RadioOutputConfigDialog::onProtocolChanged);
 
 	/* Populate widgets from the current settings. */
+	selectByData(protocol_, (int)obs_data_get_int(settings_, SETTING_PROTOCOL));
 	host_->setText(QString::fromUtf8(obs_data_get_string(settings_, SETTING_HOST)));
 	port_->setValue((int)obs_data_get_int(settings_, SETTING_PORT));
 	mount_->setText(QString::fromUtf8(obs_data_get_string(settings_, SETTING_MOUNT)));
@@ -148,10 +159,24 @@ RadioOutputConfigDialog::RadioOutputConfigDialog(obs_data_t *settings, QWidget *
 	reconnect_delay_->setValue((int)obs_data_get_int(settings_, SETTING_RECONNECT_DELAY));
 	reconnect_max_->setValue((int)obs_data_get_int(settings_, SETTING_RECONNECT_MAX));
 	start_with_streaming_->setChecked(obs_data_get_bool(settings_, SETTING_START_WITH_STREAMING));
+
+	/* Apply initial mount visibility based on the loaded protocol. */
+	onProtocolChanged(protocol_->currentIndex());
+}
+
+void RadioOutputConfigDialog::onProtocolChanged(int /*index*/)
+{
+	/* SHOUTcast v1 has no concept of a mount path; hide the Mount row so
+	 * the UI matches what the protocol actually supports.  The value is
+	 * preserved in the obs_data_t so toggling back to Icecast restores
+	 * the previous mount without re-typing. */
+	const bool is_shoutcast = (protocol_->currentData().toInt() == RADIO_PROTOCOL_SHOUTCAST);
+	server_form_->setRowVisible(mount_row_index_, !is_shoutcast);
 }
 
 void RadioOutputConfigDialog::onAccept()
 {
+	obs_data_set_int(settings_, SETTING_PROTOCOL, protocol_->currentData().toInt());
 	obs_data_set_string(settings_, SETTING_HOST, host_->text().toUtf8().constData());
 	obs_data_set_int(settings_, SETTING_PORT, port_->value());
 	obs_data_set_string(settings_, SETTING_MOUNT, mount_->text().toUtf8().constData());

--- a/src/radio-output-config-dialog.hpp
+++ b/src/radio-output-config-dialog.hpp
@@ -22,6 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
+#include <QFormLayout>
 #include <QLineEdit>
 #include <QSpinBox>
 

--- a/src/radio-output-config-dialog.hpp
+++ b/src/radio-output-config-dialog.hpp
@@ -47,14 +47,24 @@ private slots:
 private: // NOLINT(readability-redundant-access-specifiers) — keeps data members visually separate from Qt slots
 	obs_data_t *settings_;
 
+	/* Server group: the protocol combo drives mount-row visibility via
+	 * the protocol-changed slot. */
+	QComboBox *protocol_;
 	QLineEdit *host_;
 	QSpinBox *port_;
 	QLineEdit *mount_;
 	QLineEdit *password_;
+
+	QFormLayout *server_form_;
+	int mount_row_index_;
+
 	QComboBox *codec_;
 	QComboBox *bitrate_;
 	QCheckBox *reconnect_enabled_;
 	QSpinBox *reconnect_delay_;
 	QSpinBox *reconnect_max_;
 	QCheckBox *start_with_streaming_;
+
+private slots: // NOLINT(readability-redundant-access-specifiers)
+	void onProtocolChanged(int index);
 };

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -45,6 +45,7 @@ static void radio_output_update(void *data, obs_data_t *settings)
 	context->password = bstrdup(obs_data_get_string(settings, SETTING_PASSWORD));
 	context->codec = (int)obs_data_get_int(settings, SETTING_CODEC);
 	context->bitrate = (int)obs_data_get_int(settings, SETTING_BITRATE);
+	context->protocol = (int)obs_data_get_int(settings, SETTING_PROTOCOL);
 
 	context->reconnect_enabled = obs_data_get_bool(settings, SETTING_RECONNECT);
 	/* Setting stores seconds; convert to milliseconds for internal use. */
@@ -179,7 +180,13 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout)
 	shout_set_mount(shout, context->mount);
 	shout_set_password(shout, context->password);
 	shout_set_agent(shout, agent);
-	shout_set_protocol(shout, SHOUT_PROTOCOL_HTTP);
+
+	/* libshout protocol mapping.  SHOUT_PROTOCOL_ICY is SHOUTcast v1
+	 * (no mount path, ICY metadata headers); SHOUT_PROTOCOL_HTTP is
+	 * Icecast 2.x (standard HTTP PUT / SOURCE with a mount path). */
+	const int shout_proto = (context->protocol == RADIO_PROTOCOL_SHOUTCAST) ? SHOUT_PROTOCOL_ICY
+										: SHOUT_PROTOCOL_HTTP;
+	shout_set_protocol(shout, shout_proto);
 
 	/* libshout 2.4.6: shout_set_content_format() only maps SHOUT_FORMAT_MP3
 	 * to "audio/mpeg" when usage == SHOUT_USAGE_AUDIO.  Without it the
@@ -306,6 +313,15 @@ static bool radio_output_start(void *data)
 	obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
 	return false;
 #else
+	/* SHOUTcast v1 (ICY) only carries MP3.  Warn loudly if the user
+	 * picked Opus or Vorbis alongside SHOUTcast — the connection will
+	 * almost certainly be rejected by the server and we want the log
+	 * to make the cause obvious. */
+	if (context->protocol == RADIO_PROTOCOL_SHOUTCAST && context->codec != RADIO_CODEC_MP3) {
+		obs_log(LOG_WARNING,
+			"SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server");
+	}
+
 	/* --- Initialize audio encoder --- */
 	if (context->codec == RADIO_CODEC_MP3) {
 #ifdef HAVE_LAME
@@ -580,6 +596,7 @@ static void radio_output_get_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, SETTING_RECONNECT_DELAY, 5);
 	obs_data_set_default_int(settings, SETTING_RECONNECT_MAX, 10);
 	obs_data_set_default_bool(settings, SETTING_START_WITH_STREAMING, false);
+	obs_data_set_default_int(settings, SETTING_PROTOCOL, RADIO_PROTOCOL_ICECAST);
 }
 
 struct obs_output_info radio_output_info = {

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -81,6 +81,11 @@ struct radio_output {
 #define RADIO_CODEC_MP3    1
 #define RADIO_CODEC_VORBIS 2 // Phase 2
 
+// Protocol identifiers for the config + UI.  Mapped to libshout's
+// SHOUT_PROTOCOL_HTTP / SHOUT_PROTOCOL_ICY in shout_apply_settings.
+#define RADIO_PROTOCOL_ICECAST   0
+#define RADIO_PROTOCOL_SHOUTCAST 1
+
 static inline void set_state(struct radio_output *context, radio_state_t new_state)
 {
 	pthread_mutex_lock(&context->state_mutex);
@@ -112,6 +117,7 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout);
 #define SETTING_RECONNECT_DELAY      "reconnect_delay"
 #define SETTING_RECONNECT_MAX        "reconnect_max"
 #define SETTING_START_WITH_STREAMING "start_with_streaming"
+#define SETTING_PROTOCOL             "protocol"
 
 extern struct obs_output_info radio_output_info;
 


### PR DESCRIPTION
**Summary**
- First of Phase 2 Section D (single-item). Adds `SETTING_PROTOCOL` with two values (Icecast / SHOUTcast v1) and wires it through the config dialog, persistence layer, and libshout start path.
- Replaces the previously-hardcoded `shout_set_protocol(SHOUT_PROTOCOL_HTTP)` call with a mapping based on the user's choice: Icecast → `SHOUT_PROTOCOL_HTTP`, SHOUTcast → `SHOUT_PROTOCOL_ICY`.
- Protocol dropdown is the first field in the Server group of the config dialog. Mount row visibility is dynamic: hidden when SHOUTcast is selected (SHOUTcast v1 has no concept of a mount path), shown otherwise. Mount *value* is preserved in config.json across protocol toggles so flipping Icecast ↔ SHOUTcast doesn't require re-typing.
- SHOUTcast v1 is MP3-only; if the user selects Opus or Vorbis alongside SHOUTcast, `radio_output_start` logs a clear warning (`SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server`) and proceeds — letting libshout / the server surface the failure rather than front-loading validation.

Fixes #31.

**Files touched**
- `src/radio-output.h` — new `SETTING_PROTOCOL` + `RADIO_PROTOCOL_ICECAST/SHOUTCAST` constants.
- `src/radio-output.c` — read setting in `radio_output_update`; use it in `shout_apply_settings`; incompatibility warning in `radio_output_start`; default in `radio_output_get_defaults`.
- `src/frontend-wire.cpp` — default in `apply_defaults` so fresh `config.json` loads default to Icecast.
- `src/radio-output-config-dialog.{hpp,cpp}` — protocol combo, `onProtocolChanged` slot, dynamic mount row visibility via `QFormLayout::setRowVisible`. Updated `buildServerGroup` signature to pass the form + mount-row index out so the slot can address the right row.
- `data/locale/en-US.ini` — three new strings: `RadioOutput.Server.Protocol`, `.Icecast`, `.SHOUTcast`.

**Non-obvious design calls**
- **Mount value preserved, not cleared, when SHOUTcast is picked.** Makes round-tripping between Icecast/SHOUTcast friction-free. The mount value is still written to libshout via `shout_set_mount` on SHOUTcast connects but libshout ignores it for the ICY protocol.
- **Warning-on-start for codec incompatibility, not dialog-time validation.** Simpler scope for Phase 2. The dropdown already visually nudges the user and the server will reject the connection with a clear libshout error if the codec truly can't be negotiated. Dialog-time validation ("SHOUTcast requires MP3 — want to switch?") is deferrable polish.
- **Initial mount visibility applied post-populate.** The constructor calls `onProtocolChanged(protocol_->currentIndex())` after `selectByData(protocol_, ...)` so the mount row state matches the loaded config on dialog open, not just after the user clicks the dropdown.

**Test plan**

- [x] CI passes (clang-format, gersemi, build × 4 platforms, CodeQL, Clang-Tidy via reviewdog, check-commits)

### Setup

```bash
cd ~/Code/Tech-Noid-Systems/obs-radio-output
git fetch origin feat/shoutcast-v1
git checkout feat/shoutcast-v1
./build-and-install-macos.sh
```

⌘Q OBS, relaunch. Ensure the local Icecast container is up (`docker run -d --name icecast -p 8000:8000 moul/icecast` if needed).

Tail the log in a second terminal:
```bash
tail -F ~/Library/Application\ Support/obs-studio/logs/*.txt
```

#### Test 23 — Protocol dropdown and dynamic mount visibility ✅ PASS

1. Tools → Radio Output…
2. Confirm a **Protocol** dropdown appears at the top of the Server group with two options: **Icecast**, **SHOUTcast (v1)**.
3. With Icecast selected: **Mount Point** field is visible; default is `/stream`.
4. Change Protocol to **SHOUTcast (v1)** — watch the Mount row.

**Pass:**
- [x] Mount row is **hidden** when SHOUTcast selected
- [x] No layout glitch — Password row slides up smoothly
- [x] Change back to Icecast — Mount row reappears with the previously-entered value preserved (try typing something in Mount first, toggle to SHOUTcast, back to Icecast → value still there)

#### Test 24 — Icecast happy path (regression) ✅ PASS

1. Protocol: Icecast. Host: localhost. Port: 8000. Mount: /stream. Password: hackme. Codec: MP3. OK.
2. Dock → Start.

**Pass:**
- [x] Dock goes Disconnected → Connecting → Live
- [x] Log shows `Connected to localhost:8000/stream`
- [x] VLC on `http://localhost:8000/stream` plays the audio
- [x] Stop — clean teardown

#### Test 25 — SHOUTcast v1 end-to-end ⏸ SKIPPED (no SHOUTcast v1 server available; the ICY path is exercised as the error path in Test 26, and Icecast → libshout mapping is verified in Test 24)

**If you don't have SHOUTcast v1 handy**, skip this test and log that in the PR — the behavior can be verified later against a real SHOUTcast station.

1. Configure Host / Port / Password for your SHOUTcast v1 server. Protocol: SHOUTcast (v1). Codec: MP3. OK.
2. Dock → Start.

**Pass:**
- [ ] Connection succeeds; log shows the usual `Connected to host:port` line
- [ ] Audio plays on the stream URL
- [ ] Stop works cleanly

#### Test 26 — Codec / protocol incompatibility warning ✅ PASS

1. Protocol: SHOUTcast (v1). Codec: **Opus** (or Vorbis). OK.
2. Dock → Start.

**Pass:**
- [x] Log shows the warning: `SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server`
- [x] Connection attempt proceeds (server will likely reject with a libshout error — that's fine; just verify the warning fires so the user has a clear diagnostic)
- [x] Click Stop; teardown works regardless of connection outcome

#### Test 27 — Config persistence across OBS restart ✅ PASS

1. Set Protocol: SHOUTcast (v1). OK.
2. ⌘Q OBS, relaunch.
3. Open Tools → Radio Output…

**Pass:**
- [x] Protocol dropdown remembers SHOUTcast
- [x] Mount row is hidden on open (matches the loaded protocol)

### If a test fails
- OBS log: `~/Library/Application Support/obs-studio/logs/*.txt`
- Config: `~/Library/Application Support/obs-studio/plugin_config/obs-radio-output/config.json` — verify `"protocol"` value (0 = Icecast, 1 = SHOUTcast)
