### PR TITLE
feat(encoder): codec vtable + libopus/libogg Opus encoder (§C.2 + §C.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ target_sources(
     src/plugin-main.c
     src/radio-output.c
     src/radio-output.h
+    src/radio-encoder.h
+    src/radio-opus-encoder.c
     src/reconnect.c
     src/reconnect.h
     src/frontend-wire.cpp

--- a/src/radio-encoder.h
+++ b/src/radio-encoder.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct radio_output;
+
+/*
+ * Codec vtable.  One instance per supported codec (radio_encoder_mp3,
+ * radio_encoder_opus, …).  Selected at radio_output_start() time based on
+ * context->codec, then dispatched through context->encoder.
+ *
+ * The encoder is responsible for turning planar IEEE-float PCM into the
+ * bytes that go on the wire (MP3 frames, Ogg/Opus pages, etc.).  The ring
+ * buffer, send thread, reconnect logic, and libshout handling stay in
+ * radio-output.c; encoders only produce bytes.
+ *
+ * Thread model:
+ *   - init / destroy / flush: OBS main thread in radio_output_start and
+ *     radio_output_teardown.  flush() runs after the send thread has been
+ *     joined, so its output is handed to shout_send directly.
+ *   - encode_frame:            OBS audio thread (radio_output_raw_audio).
+ *
+ * Ownership of the scratch output buffer is with the caller; encoders must
+ * never write more than `cap` bytes.  Encoders that buffer input internally
+ * (Opus requires whole 20 ms frames) may legally return 0 for calls that
+ * don't complete a frame.
+ */
+struct radio_encoder_ops {
+	const char *name;          /* "mp3", "opus" — appears in log lines */
+	unsigned int shout_format; /* SHOUT_FORMAT_MP3 or SHOUT_FORMAT_OGG */
+
+	/*
+	 * Initialize encoder state at the given samplerate (Hz) and channel
+	 * count (1 or 2).  If the container format emits startup bytes (Ogg
+	 * OpusHead + OpusTags pages, for example), the encoder bmalloc()s a
+	 * buffer, writes them into it, and returns (*out_headers, *out_bytes).
+	 * The caller takes ownership of the buffer and releases it with bfree.
+	 * Encoders with no startup bytes (MP3) set both out params to 0/NULL.
+	 *
+	 * Returns true on success.  On failure the encoder must clean up its
+	 * own state; destroy() will NOT be called after a failed init.
+	 */
+	bool (*init)(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+		     size_t *out_bytes);
+
+	/* Release all encoder state.  Safe to call multiple times. */
+	void (*destroy)(struct radio_output *context);
+
+	/*
+	 * Encode one batch of planar float samples into out[0..cap).  Returns
+	 * the byte count written (>= 0) or -1 on error.  0 is valid — it means
+	 * the encoder buffered the input and will emit bytes on a future call.
+	 */
+	int (*encode_frame)(struct radio_output *context, const float *left, const float *right, size_t frames,
+			    uint8_t *out, size_t cap);
+
+	/*
+	 * Flush any residual bytes at stream end (LAME: lame_encode_flush;
+	 * Opus: final EOS page).  Returns byte count or -1 on error.  Called
+	 * once during teardown, on the main thread, after the send thread has
+	 * been stopped.
+	 */
+	int (*flush)(struct radio_output *context, uint8_t *out, size_t cap);
+
+	/*
+	 * Upper bound on bytes encode_frame() may produce for `frames` input
+	 * samples per channel.  Used by radio_output_raw_audio to size its
+	 * scratch buffer.  Must account for any pending internal buffering.
+	 */
+	size_t (*max_output_for)(struct radio_output *context, size_t frames);
+};
+
+extern const struct radio_encoder_ops radio_encoder_mp3;
+extern const struct radio_encoder_ops radio_encoder_opus;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/radio-encoder.h
+++ b/src/radio-encoder.h
@@ -70,6 +70,28 @@ struct radio_encoder_ops {
 	int (*flush)(struct radio_output *context, uint8_t *out, size_t cap);
 
 	/*
+	 * Called from the reconnect thread after shout_open() succeeds on the
+	 * new connection, BEFORE context->shout is made visible to the send
+	 * thread.  Encoders with container formats that require startup
+	 * headers (Ogg/Opus: OpusHead + OpusTags pages) reset their container
+	 * state, re-emit those headers, and return them via out_headers /
+	 * out_bytes — same ownership contract as init().  Encoders without
+	 * container overhead (MP3) return 0 bytes.
+	 *
+	 * This exists because on a reconnect Icecast treats the new source
+	 * connection as a fresh stream: the old mount's cached container
+	 * headers are gone, and listeners that rejoin (or joined against the
+	 * new Icecast instance after a crash) cannot decode Ogg/Opus without
+	 * a BOS page.  Frame-synced codecs like MP3 don't care.
+	 *
+	 * The encoder's compression state (OpusEncoder perceptual context,
+	 * LAME state) is intentionally preserved across reconnect — only the
+	 * container is reset.  Returns 0 on success (even if 0 bytes written)
+	 * and -1 on error.
+	 */
+	int (*on_reconnect)(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes);
+
+	/*
 	 * Upper bound on bytes encode_frame() may produce for `frames` input
 	 * samples per channel.  Used by radio_output_raw_audio to size its
 	 * scratch buffer.  Must account for any pending internal buffering.

--- a/src/radio-opus-encoder.c
+++ b/src/radio-opus-encoder.c
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * Opus encoder — libopus (codec) + libogg (container).
+ *
+ * Implements the radio_encoder_ops vtable so the rest of radio-output.c
+ * can treat codec selection as a dispatch through context->encoder.
+ *
+ * Pipeline:
+ *   1. init()   — create OpusEncoder + ogg_stream_state; build OpusHead +
+ *                 OpusTags packets; flush both into header pages returned
+ *                 to the caller.  Those pages are queued on the shared
+ *                 send buffer so they hit the wire before audio.
+ *   2. encode() — interleave incoming PCM into a 20 ms accumulator.  When
+ *                 full (960 samples/ch @ 48 kHz), call opus_encode_float,
+ *                 wrap the packet in an ogg_packet, push through the
+ *                 stream state, and pull out any pages ready for emission.
+ *   3. flush()  — encode a final frame with e_o_s set (zero-padded if we
+ *                 had no residual audio) and force-flush any remaining
+ *                 pages.  Emits the terminating Ogg page.
+ *
+ * Design choices:
+ *   • Require 48 kHz input.  OBS's default is 48 kHz; if the user has
+ *     lowered it we fail init with a clear message rather than silently
+ *     piping mis-rated PCM into libopus.
+ *   • Mono/stereo via channel mapping family 0.  Family 1 (surround) is
+ *     out of scope for internet radio.
+ *   • Packets go through ogg_stream_pageout during the audio loop, then
+ *     ogg_stream_flush at teardown.  Default Ogg pagination (~4 KB per
+ *     page) yields ~250 ms of buffering — negligible next to our 14 s
+ *     ring buffer.
+ */
+
+#include "radio-encoder.h"
+#include "radio-output.h"
+
+#include <plugin-support.h>
+#include <util/base.h>
+#include <util/bmem.h>
+
+#ifdef HAVE_OPUS
+
+#include <opus/opus.h>
+#include <ogg/ogg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define OPUS_FRAME_SIZE 960  /* 20 ms at 48 kHz */
+#define OPUS_MAX_PACKET 4000 /* RFC 7845 practical upper bound for 20 ms */
+
+/*
+ * Per-output Opus state.  Lives in radio_output::encoder_priv; allocated
+ * in opus_init, released in opus_destroy.
+ */
+struct opus_state {
+	OpusEncoder *enc;
+	ogg_stream_state os;
+	bool os_initialized;
+
+	uint32_t sample_rate; /* must be 48000 (libopus constraint for our path) */
+	int channels;         /* 1 or 2 */
+
+	/* Interleaved PCM accumulator (holds up to one 20 ms frame). */
+	float accum[OPUS_FRAME_SIZE * 2];
+	size_t accum_fill; /* sample-frames currently buffered */
+
+	int64_t packetno;
+	int64_t granulepos;
+};
+
+/*
+ * Append one Ogg page (header + body) to a fixed-size output buffer.
+ * Returns false if the write would overflow cap; the caller then reports
+ * -1 to raw_audio, which drops the pages — better than a wild write.
+ * The ring buffer is 256 KB so this limit should never fire in practice
+ * for a single audio callback.
+ */
+static bool write_page_fixed(uint8_t *out, size_t cap, size_t *pos, const ogg_page *og)
+{
+	size_t need = *pos + (size_t)og->header_len + (size_t)og->body_len;
+	if (need > cap)
+		return false;
+	memcpy(out + *pos, og->header, (size_t)og->header_len);
+	*pos += (size_t)og->header_len;
+	memcpy(out + *pos, og->body, (size_t)og->body_len);
+	*pos += (size_t)og->body_len;
+	return true;
+}
+
+/*
+ * Append one Ogg page to a growable bmalloc buffer.  Used only by init()
+ * to build the header-page blob, which is a few hundred bytes total.
+ */
+static void append_page(uint8_t **dst, size_t *dst_len, size_t *dst_cap, const ogg_page *og)
+{
+	size_t need = *dst_len + (size_t)og->header_len + (size_t)og->body_len;
+	if (need > *dst_cap) {
+		size_t new_cap = *dst_cap ? *dst_cap : 1024;
+		while (new_cap < need)
+			new_cap *= 2;
+		*dst = brealloc(*dst, new_cap);
+		*dst_cap = new_cap;
+	}
+	memcpy(*dst + *dst_len, og->header, (size_t)og->header_len);
+	*dst_len += (size_t)og->header_len;
+	memcpy(*dst + *dst_len, og->body, (size_t)og->body_len);
+	*dst_len += (size_t)og->body_len;
+}
+
+/*
+ * Encode the single full 20 ms frame currently in st->accum, wrap it as
+ * an Ogg packet, push through the stream, and pull whatever pages come
+ * out into the caller's fixed-size buffer.  Caller manages whether to
+ * use pageout (during normal audio) or flush (at teardown).
+ */
+static int emit_one_frame(struct opus_state *st, uint8_t *out, size_t cap, size_t *pos, bool last)
+{
+	uint8_t pkt[OPUS_MAX_PACKET];
+	int pkt_bytes = opus_encode_float(st->enc, st->accum, OPUS_FRAME_SIZE, pkt, (opus_int32)sizeof(pkt));
+	if (pkt_bytes < 0) {
+		obs_log(LOG_ERROR, "opus_encode_float failed: %s", opus_strerror(pkt_bytes));
+		return -1;
+	}
+
+	st->granulepos += OPUS_FRAME_SIZE;
+
+	ogg_packet op = {0};
+	op.packet = pkt;
+	op.bytes = pkt_bytes;
+	op.b_o_s = 0;
+	op.e_o_s = last ? 1 : 0;
+	op.granulepos = st->granulepos;
+	op.packetno = st->packetno++;
+	if (ogg_stream_packetin(&st->os, &op) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin failed");
+		return -1;
+	}
+
+	ogg_page page;
+	int (*page_fn)(ogg_stream_state *, ogg_page *) = last ? ogg_stream_flush : ogg_stream_pageout;
+	while (page_fn(&st->os, &page)) {
+		if (!write_page_fixed(out, cap, pos, &page)) {
+			obs_log(LOG_ERROR, "Opus: scratch buffer overflow emitting page");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static bool opus_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+		      size_t *out_bytes)
+{
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	if (sample_rate != 48000) {
+		obs_log(LOG_ERROR,
+			"Opus requires 48 kHz audio; OBS is at %u Hz (change in Settings → Audio → Sample Rate)",
+			sample_rate);
+		return false;
+	}
+	if (channels != 1 && channels != 2) {
+		obs_log(LOG_ERROR, "Opus: unsupported channel count %d (must be 1 or 2)", channels);
+		return false;
+	}
+
+	struct opus_state *st = bzalloc(sizeof(struct opus_state));
+	st->sample_rate = sample_rate;
+	st->channels = channels;
+
+	int err = 0;
+	st->enc = opus_encoder_create((opus_int32)sample_rate, channels, OPUS_APPLICATION_AUDIO, &err);
+	if (!st->enc || err != OPUS_OK) {
+		obs_log(LOG_ERROR, "opus_encoder_create failed: %s", opus_strerror(err));
+		bfree(st);
+		return false;
+	}
+
+	/* Configure for internet-radio-style stereo music:
+	 *   - bitrate from user setting (kbps → bps)
+	 *   - signal hint = music (vs. voice)
+	 *   - complexity 10 = highest encoder quality
+	 *   - VBR on (default true, but set explicitly)
+	 */
+	opus_encoder_ctl(st->enc, OPUS_SET_BITRATE((opus_int32)context->bitrate * 1000));
+	opus_encoder_ctl(st->enc, OPUS_SET_SIGNAL(OPUS_SIGNAL_MUSIC));
+	opus_encoder_ctl(st->enc, OPUS_SET_COMPLEXITY(10));
+	opus_encoder_ctl(st->enc, OPUS_SET_VBR(1));
+
+	/* Pre-skip: samples the decoder discards at stream start to account for
+	 * encoder lookahead.  Passed through in OpusHead so the player drops
+	 * the right amount.  Default 3840 if the query fails (shouldn't). */
+	opus_int32 preskip = 3840;
+	opus_encoder_ctl(st->enc, OPUS_GET_LOOKAHEAD(&preskip));
+
+	/* Random-ish Ogg serial number — any int32 that doesn't collide with a
+	 * second logical stream in the same file/stream is fine.  We only ever
+	 * carry one logical stream, so any value is fine. */
+	unsigned int serial = (unsigned int)time(NULL);
+	serial ^= (unsigned int)(uintptr_t)st;
+	ogg_stream_init(&st->os, (int)serial);
+	st->os_initialized = true;
+
+	/* ---- OpusHead (RFC 7845 §5.1, 19 bytes for channel mapping family 0) ---- */
+	uint8_t head[19];
+	memcpy(head, "OpusHead", 8);
+	head[8] = 1;                 /* version */
+	head[9] = (uint8_t)channels; /* output channel count */
+	head[10] = (uint8_t)(preskip & 0xFF);
+	head[11] = (uint8_t)((preskip >> 8) & 0xFF);
+	head[12] = (uint8_t)(sample_rate & 0xFF);
+	head[13] = (uint8_t)((sample_rate >> 8) & 0xFF);
+	head[14] = (uint8_t)((sample_rate >> 16) & 0xFF);
+	head[15] = (uint8_t)((sample_rate >> 24) & 0xFF);
+	head[16] = 0; /* output gain low (0 = unity) */
+	head[17] = 0; /* output gain high */
+	head[18] = 0; /* channel mapping family */
+
+	ogg_packet op_head = {0};
+	op_head.packet = head;
+	op_head.bytes = sizeof(head);
+	op_head.b_o_s = 1;
+	op_head.e_o_s = 0;
+	op_head.granulepos = 0;
+	op_head.packetno = st->packetno++;
+	if (ogg_stream_packetin(&st->os, &op_head) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusHead) failed");
+		ogg_stream_clear(&st->os);
+		opus_encoder_destroy(st->enc);
+		bfree(st);
+		return false;
+	}
+
+	/* ---- OpusTags (RFC 7845 §5.2) ---- */
+	const char *vendor = "obs-radio-output";
+	const size_t vendor_len = strlen(vendor);
+	const size_t tags_len = 8 + 4 + vendor_len + 4;
+	uint8_t *tags = bmalloc(tags_len);
+	memcpy(tags, "OpusTags", 8);
+	const uint32_t vlen32 = (uint32_t)vendor_len;
+	tags[8] = (uint8_t)(vlen32 & 0xFF);
+	tags[9] = (uint8_t)((vlen32 >> 8) & 0xFF);
+	tags[10] = (uint8_t)((vlen32 >> 16) & 0xFF);
+	tags[11] = (uint8_t)((vlen32 >> 24) & 0xFF);
+	memcpy(tags + 12, vendor, vendor_len);
+	tags[12 + vendor_len + 0] = 0;
+	tags[12 + vendor_len + 1] = 0;
+	tags[12 + vendor_len + 2] = 0;
+	tags[12 + vendor_len + 3] = 0;
+
+	ogg_packet op_tags = {0};
+	op_tags.packet = tags;
+	op_tags.bytes = (long)tags_len;
+	op_tags.b_o_s = 0;
+	op_tags.e_o_s = 0;
+	op_tags.granulepos = 0;
+	op_tags.packetno = st->packetno++;
+	if (ogg_stream_packetin(&st->os, &op_tags) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusTags) failed");
+		bfree(tags);
+		ogg_stream_clear(&st->os);
+		opus_encoder_destroy(st->enc);
+		bfree(st);
+		return false;
+	}
+
+	/* Spec says OpusHead and OpusTags each MUST live on their own page; the
+	 * convention is to force two flushes right here. */
+	uint8_t *pages = NULL;
+	size_t pages_len = 0;
+	size_t pages_cap = 0;
+	ogg_page page;
+	while (ogg_stream_flush(&st->os, &page))
+		append_page(&pages, &pages_len, &pages_cap, &page);
+
+	bfree(tags);
+
+	context->encoder_priv = st;
+	*out_headers = pages;
+	*out_bytes = pages_len;
+
+	obs_log(LOG_INFO, "Opus encoder: %u Hz, %d ch, %d kbps, pre-skip %d", sample_rate, channels, context->bitrate,
+		preskip);
+	return true;
+}
+
+static void opus_destroy(struct radio_output *context)
+{
+	struct opus_state *st = context->encoder_priv;
+	if (!st)
+		return;
+
+	if (st->os_initialized) {
+		ogg_stream_clear(&st->os);
+		st->os_initialized = false;
+	}
+	if (st->enc) {
+		opus_encoder_destroy(st->enc);
+		st->enc = NULL;
+	}
+	bfree(st);
+	context->encoder_priv = NULL;
+}
+
+static int opus_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+			     uint8_t *out, size_t cap)
+{
+	struct opus_state *st = context->encoder_priv;
+	if (!st)
+		return -1;
+
+	size_t pos = 0;
+	size_t i = 0;
+
+	while (i < frames) {
+		size_t take = OPUS_FRAME_SIZE - st->accum_fill;
+		size_t avail = frames - i;
+		if (take > avail)
+			take = avail;
+
+		if (st->channels == 2) {
+			for (size_t k = 0; k < take; k++) {
+				st->accum[(st->accum_fill + k) * 2 + 0] = left[i + k];
+				st->accum[(st->accum_fill + k) * 2 + 1] = right[i + k];
+			}
+		} else {
+			/* Mono downmix — average the two channels.  OBS always
+			 * hands us stereo in data[0]/data[1]; if mono is ever
+			 * added to the UI this keeps both channels represented. */
+			for (size_t k = 0; k < take; k++)
+				st->accum[st->accum_fill + k] = 0.5f * (left[i + k] + right[i + k]);
+		}
+		st->accum_fill += take;
+		i += take;
+
+		if (st->accum_fill == OPUS_FRAME_SIZE) {
+			if (emit_one_frame(st, out, cap, &pos, false) < 0)
+				return -1;
+			st->accum_fill = 0;
+		}
+	}
+
+	return (int)pos;
+}
+
+static int opus_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	struct opus_state *st = context->encoder_priv;
+	if (!st)
+		return 0;
+
+	size_t pos = 0;
+
+	/* Always emit exactly one terminating frame with e_o_s set so the
+	 * decoder sees a proper EOS marker.  Zero-pad whatever residual PCM
+	 * sits in the accumulator — silence is the most honest filler. */
+	const size_t total = OPUS_FRAME_SIZE * (size_t)st->channels;
+	const size_t start = st->accum_fill * (size_t)st->channels;
+	for (size_t k = start; k < total; k++)
+		st->accum[k] = 0.0f;
+	st->accum_fill = OPUS_FRAME_SIZE;
+	if (emit_one_frame(st, out, cap, &pos, true) < 0)
+		return -1;
+	st->accum_fill = 0;
+
+	/* Force any still-buffered pages out of ogg_stream. */
+	ogg_page page;
+	while (ogg_stream_flush(&st->os, &page)) {
+		if (!write_page_fixed(out, cap, &pos, &page))
+			return -1;
+	}
+
+	return (int)pos;
+}
+
+static size_t opus_max_output_for(struct radio_output *context, size_t frames)
+{
+	struct opus_state *st = context->encoder_priv;
+	if (!st)
+		return 16 * 1024;
+
+	/* Upper bound for this call: ceil((new frames + residual) / 960)
+	 * packets, each bounded by OPUS_MAX_PACKET, plus Ogg page overhead. */
+	size_t total = frames + st->accum_fill;
+	size_t packets = total / OPUS_FRAME_SIZE + 1;
+	return packets * (OPUS_MAX_PACKET + 300);
+}
+
+const struct radio_encoder_ops radio_encoder_opus = {
+	.name = "opus",
+#ifdef HAVE_LIBSHOUT
+	.shout_format = SHOUT_FORMAT_OGG,
+#else
+	.shout_format = 0,
+#endif
+	.init = opus_init,
+	.destroy = opus_destroy,
+	.encode_frame = opus_encode_frame,
+	.flush = opus_flush,
+	.max_output_for = opus_max_output_for,
+};
+
+#else /* !HAVE_OPUS — stub so the plugin still links when libopus is absent */
+
+static bool opus_stub_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+			   size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(sample_rate);
+	UNUSED_PARAMETER(channels);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	obs_log(LOG_ERROR, "Opus encoding not available — rebuild with libopus + libogg");
+	return false;
+}
+
+static void opus_stub_destroy(struct radio_output *context)
+{
+	UNUSED_PARAMETER(context);
+}
+
+static int opus_stub_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+				  uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(left);
+	UNUSED_PARAMETER(right);
+	UNUSED_PARAMETER(frames);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return -1;
+}
+
+static int opus_stub_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return 0;
+}
+
+static size_t opus_stub_max_output_for(struct radio_output *context, size_t frames)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(frames);
+	return 0;
+}
+
+const struct radio_encoder_ops radio_encoder_opus = {
+	.name = "opus",
+	.shout_format = 0,
+	.init = opus_stub_init,
+	.destroy = opus_stub_destroy,
+	.encode_frame = opus_stub_encode_frame,
+	.flush = opus_stub_flush,
+	.max_output_for = opus_stub_max_output_for,
+};
+
+#endif /* HAVE_OPUS */

--- a/src/radio-opus-encoder.c
+++ b/src/radio-opus-encoder.c
@@ -61,6 +61,7 @@ struct opus_state {
 
 	uint32_t sample_rate; /* must be 48000 (libopus constraint for our path) */
 	int channels;         /* 1 or 2 */
+	opus_int32 preskip;   /* queried at init; re-used when re-emitting headers on reconnect */
 
 	/* Interleaved PCM accumulator (holds up to one 20 ms frame). */
 	float accum[OPUS_FRAME_SIZE * 2];
@@ -68,6 +69,10 @@ struct opus_state {
 
 	int64_t packetno;
 	int64_t granulepos;
+
+	/* Reconnect counter — xor'd into the Ogg serial on each reset so
+	 * back-to-back reconnects never collide on the same serial. */
+	unsigned int reconnect_epoch;
 };
 
 /*
@@ -149,6 +154,95 @@ static int emit_one_frame(struct opus_state *st, uint8_t *out, size_t cap, size_
 	return 0;
 }
 
+/*
+ * Build OpusHead + OpusTags packets, push them through st->os, and flush
+ * the resulting pages into a fresh bmalloc'd buffer returned via
+ * out_headers/out_bytes.  Shared between init() and on_reconnect() — the
+ * only difference between the two call sites is whether ogg_stream_state
+ * is new or just-reset.
+ *
+ * Expects st->os to be freshly initialized and st->packetno = 0.
+ * Returns true on success, false if libogg rejects a packetin or a bmalloc
+ * fails — in practice both should be unreachable.
+ */
+static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_headers, size_t *out_bytes)
+{
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	/* ---- OpusHead (RFC 7845 §5.1, 19 bytes for channel mapping family 0) ---- */
+	uint8_t head[19];
+	memcpy(head, "OpusHead", 8);
+	head[8] = 1;                     /* version */
+	head[9] = (uint8_t)st->channels; /* output channel count */
+	head[10] = (uint8_t)(st->preskip & 0xFF);
+	head[11] = (uint8_t)((st->preskip >> 8) & 0xFF);
+	head[12] = (uint8_t)(st->sample_rate & 0xFF);
+	head[13] = (uint8_t)((st->sample_rate >> 8) & 0xFF);
+	head[14] = (uint8_t)((st->sample_rate >> 16) & 0xFF);
+	head[15] = (uint8_t)((st->sample_rate >> 24) & 0xFF);
+	head[16] = 0; /* output gain low (0 = unity) */
+	head[17] = 0; /* output gain high */
+	head[18] = 0; /* channel mapping family */
+
+	ogg_packet op_head = {0};
+	op_head.packet = head;
+	op_head.bytes = sizeof(head);
+	op_head.b_o_s = 1;
+	op_head.e_o_s = 0;
+	op_head.granulepos = 0;
+	op_head.packetno = st->packetno++;
+	if (ogg_stream_packetin(&st->os, &op_head) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusHead) failed");
+		return false;
+	}
+
+	/* ---- OpusTags (RFC 7845 §5.2) ---- */
+	const char *vendor = "obs-radio-output";
+	const size_t vendor_len = strlen(vendor);
+	const size_t tags_len = 8 + 4 + vendor_len + 4;
+	uint8_t *tags = bmalloc(tags_len);
+	memcpy(tags, "OpusTags", 8);
+	const uint32_t vlen32 = (uint32_t)vendor_len;
+	tags[8] = (uint8_t)(vlen32 & 0xFF);
+	tags[9] = (uint8_t)((vlen32 >> 8) & 0xFF);
+	tags[10] = (uint8_t)((vlen32 >> 16) & 0xFF);
+	tags[11] = (uint8_t)((vlen32 >> 24) & 0xFF);
+	memcpy(tags + 12, vendor, vendor_len);
+	tags[12 + vendor_len + 0] = 0;
+	tags[12 + vendor_len + 1] = 0;
+	tags[12 + vendor_len + 2] = 0;
+	tags[12 + vendor_len + 3] = 0;
+
+	ogg_packet op_tags = {0};
+	op_tags.packet = tags;
+	op_tags.bytes = (long)tags_len;
+	op_tags.b_o_s = 0;
+	op_tags.e_o_s = 0;
+	op_tags.granulepos = 0;
+	op_tags.packetno = st->packetno++;
+	if (ogg_stream_packetin(&st->os, &op_tags) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusTags) failed");
+		bfree(tags);
+		return false;
+	}
+
+	/* Spec: OpusHead and OpusTags each MUST live on their own page; flush
+	 * forces them out separately. */
+	uint8_t *pages = NULL;
+	size_t pages_len = 0;
+	size_t pages_cap = 0;
+	ogg_page page;
+	while (ogg_stream_flush(&st->os, &page))
+		append_page(&pages, &pages_len, &pages_cap, &page);
+
+	bfree(tags);
+
+	*out_headers = pages;
+	*out_bytes = pages_len;
+	return true;
+}
+
 static bool opus_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
 		      size_t *out_bytes)
 {
@@ -191,99 +285,79 @@ static bool opus_init(struct radio_output *context, uint32_t sample_rate, int ch
 
 	/* Pre-skip: samples the decoder discards at stream start to account for
 	 * encoder lookahead.  Passed through in OpusHead so the player drops
-	 * the right amount.  Default 3840 if the query fails (shouldn't). */
-	opus_int32 preskip = 3840;
-	opus_encoder_ctl(st->enc, OPUS_GET_LOOKAHEAD(&preskip));
+	 * the right amount.  Default 3840 if the query fails (shouldn't).
+	 * Stashed on st so on_reconnect() can re-emit OpusHead without
+	 * re-querying. */
+	st->preskip = 3840;
+	opus_encoder_ctl(st->enc, OPUS_GET_LOOKAHEAD(&st->preskip));
 
-	/* Random-ish Ogg serial number — any int32 that doesn't collide with a
-	 * second logical stream in the same file/stream is fine.  We only ever
-	 * carry one logical stream, so any value is fine. */
+	/* Random-ish Ogg serial number.  Any int32 that doesn't collide with a
+	 * second logical stream on the same physical stream is fine; we only
+	 * ever carry one logical stream per connection. */
 	unsigned int serial = (unsigned int)time(NULL);
 	serial ^= (unsigned int)(uintptr_t)st;
 	ogg_stream_init(&st->os, (int)serial);
 	st->os_initialized = true;
 
-	/* ---- OpusHead (RFC 7845 §5.1, 19 bytes for channel mapping family 0) ---- */
-	uint8_t head[19];
-	memcpy(head, "OpusHead", 8);
-	head[8] = 1;                 /* version */
-	head[9] = (uint8_t)channels; /* output channel count */
-	head[10] = (uint8_t)(preskip & 0xFF);
-	head[11] = (uint8_t)((preskip >> 8) & 0xFF);
-	head[12] = (uint8_t)(sample_rate & 0xFF);
-	head[13] = (uint8_t)((sample_rate >> 8) & 0xFF);
-	head[14] = (uint8_t)((sample_rate >> 16) & 0xFF);
-	head[15] = (uint8_t)((sample_rate >> 24) & 0xFF);
-	head[16] = 0; /* output gain low (0 = unity) */
-	head[17] = 0; /* output gain high */
-	head[18] = 0; /* channel mapping family */
-
-	ogg_packet op_head = {0};
-	op_head.packet = head;
-	op_head.bytes = sizeof(head);
-	op_head.b_o_s = 1;
-	op_head.e_o_s = 0;
-	op_head.granulepos = 0;
-	op_head.packetno = st->packetno++;
-	if (ogg_stream_packetin(&st->os, &op_head) != 0) {
-		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusHead) failed");
+	if (!emit_opus_container_headers(st, out_headers, out_bytes)) {
 		ogg_stream_clear(&st->os);
 		opus_encoder_destroy(st->enc);
 		bfree(st);
 		return false;
 	}
-
-	/* ---- OpusTags (RFC 7845 §5.2) ---- */
-	const char *vendor = "obs-radio-output";
-	const size_t vendor_len = strlen(vendor);
-	const size_t tags_len = 8 + 4 + vendor_len + 4;
-	uint8_t *tags = bmalloc(tags_len);
-	memcpy(tags, "OpusTags", 8);
-	const uint32_t vlen32 = (uint32_t)vendor_len;
-	tags[8] = (uint8_t)(vlen32 & 0xFF);
-	tags[9] = (uint8_t)((vlen32 >> 8) & 0xFF);
-	tags[10] = (uint8_t)((vlen32 >> 16) & 0xFF);
-	tags[11] = (uint8_t)((vlen32 >> 24) & 0xFF);
-	memcpy(tags + 12, vendor, vendor_len);
-	tags[12 + vendor_len + 0] = 0;
-	tags[12 + vendor_len + 1] = 0;
-	tags[12 + vendor_len + 2] = 0;
-	tags[12 + vendor_len + 3] = 0;
-
-	ogg_packet op_tags = {0};
-	op_tags.packet = tags;
-	op_tags.bytes = (long)tags_len;
-	op_tags.b_o_s = 0;
-	op_tags.e_o_s = 0;
-	op_tags.granulepos = 0;
-	op_tags.packetno = st->packetno++;
-	if (ogg_stream_packetin(&st->os, &op_tags) != 0) {
-		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusTags) failed");
-		bfree(tags);
-		ogg_stream_clear(&st->os);
-		opus_encoder_destroy(st->enc);
-		bfree(st);
-		return false;
-	}
-
-	/* Spec says OpusHead and OpusTags each MUST live on their own page; the
-	 * convention is to force two flushes right here. */
-	uint8_t *pages = NULL;
-	size_t pages_len = 0;
-	size_t pages_cap = 0;
-	ogg_page page;
-	while (ogg_stream_flush(&st->os, &page))
-		append_page(&pages, &pages_len, &pages_cap, &page);
-
-	bfree(tags);
 
 	context->encoder_priv = st;
-	*out_headers = pages;
-	*out_bytes = pages_len;
 
 	obs_log(LOG_INFO, "Opus encoder: %u Hz, %d ch, %d kbps, pre-skip %d", sample_rate, channels, context->bitrate,
-		preskip);
+		st->preskip);
 	return true;
+}
+
+static int opus_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	struct opus_state *st = context->encoder_priv;
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	if (!st) {
+		obs_log(LOG_ERROR, "[opus] on_reconnect called without encoder state");
+		return -1;
+	}
+
+	/* Reset the Ogg container.  Icecast treats the new source connection
+	 * as a fresh stream, so listeners need a BOS page with OpusHead before
+	 * they can decode.  A new serial is required — a logical stream
+	 * continues across pages only if its serial matches.
+	 *
+	 * The OpusEncoder itself (and the PCM accumulator) are intentionally
+	 * preserved: perceptual state like the pitch predictor and LPC
+	 * residuals is still valid across the TCP blip, and whatever partial
+	 * frame was in st->accum would otherwise be lost. */
+	if (st->os_initialized) {
+		ogg_stream_clear(&st->os);
+		st->os_initialized = false;
+	}
+	st->reconnect_epoch++;
+	unsigned int serial = (unsigned int)time(NULL);
+	serial ^= (unsigned int)(uintptr_t)st;
+	serial ^= st->reconnect_epoch * 0x9E3779B1u; /* golden-ratio hash step */
+	ogg_stream_init(&st->os, (int)serial);
+	st->os_initialized = true;
+
+	/* Restart the packet and granule counters for the new logical stream.
+	 * A listener joining this new stream has no idea the previous one
+	 * existed; from their POV playback begins at gp=0. */
+	st->packetno = 0;
+	st->granulepos = 0;
+
+	if (!emit_opus_container_headers(st, out_headers, out_bytes)) {
+		obs_log(LOG_ERROR, "[opus] failed to re-emit container headers on reconnect");
+		return -1;
+	}
+
+	obs_log(LOG_INFO, "[opus] re-emitted Ogg container headers after reconnect (%zu bytes, serial 0x%08x)",
+		*out_bytes, (unsigned int)serial);
+	return 0;
 }
 
 static void opus_destroy(struct radio_output *context)
@@ -400,6 +474,7 @@ const struct radio_encoder_ops radio_encoder_opus = {
 	.encode_frame = opus_encode_frame,
 	.flush = opus_flush,
 	.max_output_for = opus_max_output_for,
+	.on_reconnect = opus_on_reconnect,
 };
 
 #else /* !HAVE_OPUS — stub so the plugin still links when libopus is absent */
@@ -448,6 +523,14 @@ static size_t opus_stub_max_output_for(struct radio_output *context, size_t fram
 	return 0;
 }
 
+static int opus_stub_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	return 0;
+}
+
 const struct radio_encoder_ops radio_encoder_opus = {
 	.name = "opus",
 	.shout_format = 0,
@@ -456,6 +539,7 @@ const struct radio_encoder_ops radio_encoder_opus = {
 	.encode_frame = opus_stub_encode_frame,
 	.flush = opus_stub_flush,
 	.max_output_for = opus_stub_max_output_for,
+	.on_reconnect = opus_stub_on_reconnect,
 };
 
 #endif /* HAVE_OPUS */

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "radio-output.h"
+#include "radio-encoder.h"
 #include "reconnect.h"
 #include <plugin-support.h>
 
@@ -98,7 +99,9 @@ static void radio_output_teardown(struct radio_output *context)
 
 	reconnect_cancel(context);
 
-#ifdef HAVE_LAME
+#ifdef HAVE_LIBSHOUT
+	/* Stop the send thread before flushing / closing shout so the thread
+	 * can't race with our flush shout_send. */
 	if (context->send_buf) {
 		context->send_running = false;
 		pthread_mutex_lock(&context->send_mutex);
@@ -109,27 +112,23 @@ static void radio_output_teardown(struct radio_output *context)
 		pthread_cond_destroy(&context->send_cond);
 		bfree(context->send_buf);
 		context->send_buf = NULL;
-		obs_log(LOG_INFO, "MP3 send thread stopped");
+		obs_log(LOG_INFO, "Encoder send thread stopped");
 	}
-#endif /* HAVE_LAME */
 
-#ifdef HAVE_LIBSHOUT
-#ifdef HAVE_LAME
-	/* Flush remaining MP3 frames before closing the connection. */
-	if (context->lame_gfp && context->shout) {
-		uint8_t flush_buf[7200];
-		int flush_bytes = lame_encode_flush(context->lame_gfp, flush_buf, sizeof(flush_buf));
+	/* Encoder flush — trailing MP3 frames / final Ogg EOS page. */
+	if (context->encoder && context->shout) {
+		uint8_t flush_buf[16 * 1024];
+		int flush_bytes = context->encoder->flush(context, flush_buf, sizeof(flush_buf));
 		if (flush_bytes > 0) {
 			int flush_ret = shout_send(context->shout, flush_buf, (size_t)flush_bytes);
 			if (flush_ret != SHOUTERR_SUCCESS)
 				obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
 		}
 	}
-	if (context->lame_gfp) {
-		lame_close(context->lame_gfp);
-		context->lame_gfp = NULL;
+	if (context->encoder) {
+		context->encoder->destroy(context);
+		context->encoder = NULL;
 	}
-#endif /* HAVE_LAME */
 	if (context->shout) {
 		shout_close(context->shout);
 		shout_free(context->shout);
@@ -173,7 +172,7 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout)
 	char agent[64];
 	snprintf(agent, sizeof(agent), "obs-radio-output/%s", PLUGIN_VERSION);
 
-	unsigned int fmt = (context->codec == RADIO_CODEC_MP3) ? SHOUT_FORMAT_MP3 : SHOUT_FORMAT_OGG;
+	unsigned int fmt = context->encoder ? context->encoder->shout_format : SHOUT_FORMAT_MP3;
 
 	shout_set_host(shout, context->host);
 	shout_set_port(shout, (unsigned short)context->port);
@@ -198,11 +197,7 @@ void shout_apply_settings(struct radio_output *context, shout_t *shout)
 	 * audiorate = 0 and shout_sync can sleep indefinitely.  Also populates
 	 * the audio_info stats on the Icecast admin page. */
 	char ai_bitrate[16], ai_samplerate[16];
-	uint32_t sample_rate = 48000;
-#ifdef HAVE_LAME
-	if (context->lame_gfp)
-		sample_rate = (uint32_t)lame_get_in_samplerate(context->lame_gfp);
-#endif
+	uint32_t sample_rate = context->sample_rate ? context->sample_rate : 48000;
 	snprintf(ai_bitrate, sizeof(ai_bitrate), "%d", context->bitrate);
 	snprintf(ai_samplerate, sizeof(ai_samplerate), "%u", sample_rate);
 	shout_set_audio_info(shout, SHOUT_AI_BITRATE, ai_bitrate);
@@ -241,17 +236,18 @@ static void shout_handoff_cleanup(shout_t *handle)
 	}
 	pthread_detach(tid);
 }
-#endif /* HAVE_LIBSHOUT */
 
-#ifdef HAVE_LAME
 /*
- * mp3_send_thread — dequeues encoded MP3 frames from the ring buffer and
- * forwards them to libshout with proper bitrate pacing via shout_sync().
+ * encoder_send_thread — dequeues encoded bytes (MP3 frames, Ogg pages, …)
+ * from the ring buffer and forwards them to libshout with bitrate pacing
+ * via shout_sync().
  *
- * Running shout_send + shout_sync on a dedicated thread keeps the OBS audio
- * callback (raw_audio) fast: it only encodes and writes to the ring buffer.
+ * Running shout_send + shout_sync on a dedicated thread keeps the OBS
+ * audio callback (raw_audio) fast: it only encodes and writes to the ring
+ * buffer.  This is codec-agnostic; the encoder's output format is
+ * transparent at this layer.
  */
-static void *mp3_send_thread(void *data)
+static void *encoder_send_thread(void *data)
 {
 	struct radio_output *context = data;
 	uint8_t scratch[4096];
@@ -302,6 +298,167 @@ static void *mp3_send_thread(void *data)
 	}
 	return NULL;
 }
+
+/*
+ * send_buf_push — append bytes to the shared ring buffer and wake the send
+ * thread.  Used by the audio thread (encoder output) and the start path
+ * (to queue Opus startup pages before audio begins).  Drops oldest data
+ * if the buffer would overflow.
+ */
+static void send_buf_push(struct radio_output *context, const uint8_t *bytes, size_t len)
+{
+	if (!context->send_buf || len == 0)
+		return;
+
+	pthread_mutex_lock(&context->send_mutex);
+	size_t used = context->send_wpos - context->send_rpos;
+	if (used + len > SEND_BUF_CAPACITY) {
+		size_t drop = used + len - SEND_BUF_CAPACITY;
+		context->send_rpos += drop;
+		obs_log(LOG_WARNING, "send buffer full, dropped %zu bytes", drop);
+	}
+	size_t wpos = context->send_wpos % SEND_BUF_CAPACITY;
+	size_t tail = SEND_BUF_CAPACITY - wpos;
+	if (tail >= len) {
+		memcpy(context->send_buf + wpos, bytes, len);
+	} else {
+		memcpy(context->send_buf + wpos, bytes, tail);
+		memcpy(context->send_buf, bytes + tail, len - tail);
+	}
+	context->send_wpos += len;
+	pthread_cond_signal(&context->send_cond);
+	pthread_mutex_unlock(&context->send_mutex);
+}
+#endif /* HAVE_LIBSHOUT */
+
+/* -------------------------------------------------------------------------
+ * MP3 encoder vtable (libmp3lame)
+ *
+ * Thin adapters over lame_* calls so the rest of radio-output.c can dispatch
+ * through context->encoder instead of hard-coding codec paths.  Opus lives
+ * in radio-opus-encoder.c; add further codecs the same way.
+ * ---------------------------------------------------------------------- */
+
+#ifdef HAVE_LAME
+static bool mp3_encoder_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+			     size_t *out_bytes)
+{
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	context->lame_gfp = lame_init();
+	if (!context->lame_gfp) {
+		obs_log(LOG_ERROR, "lame_init() failed");
+		return false;
+	}
+	lame_set_in_samplerate(context->lame_gfp, (int)sample_rate);
+	lame_set_num_channels(context->lame_gfp, channels);
+	lame_set_out_samplerate(context->lame_gfp, 0);
+	lame_set_brate(context->lame_gfp, context->bitrate);
+	lame_set_quality(context->lame_gfp, 2);
+	if (lame_init_params(context->lame_gfp) < 0) {
+		obs_log(LOG_ERROR, "lame_init_params() failed");
+		lame_close(context->lame_gfp);
+		context->lame_gfp = NULL;
+		return false;
+	}
+	obs_log(LOG_INFO, "MP3 encoder: %u Hz, %d ch, %d kbps", sample_rate, channels, context->bitrate);
+	return true;
+}
+
+static void mp3_encoder_destroy(struct radio_output *context)
+{
+	if (context->lame_gfp) {
+		lame_close(context->lame_gfp);
+		context->lame_gfp = NULL;
+	}
+}
+
+static int mp3_encoder_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+				    uint8_t *out, size_t cap)
+{
+	if (!context->lame_gfp)
+		return -1;
+	return lame_encode_buffer_ieee_float(context->lame_gfp, left, right, (int)frames, out, (int)cap);
+}
+
+static int mp3_encoder_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	if (!context->lame_gfp)
+		return 0;
+	int n = lame_encode_flush(context->lame_gfp, out, (int)cap);
+	return n < 0 ? -1 : n;
+}
+
+static size_t mp3_encoder_max_output_for(struct radio_output *context, size_t frames)
+{
+	UNUSED_PARAMETER(context);
+	/* LAME docs: worst-case 1.25 * nsamples + 7200 bytes. */
+	return (size_t)(1.25f * (float)frames) + 7200;
+}
+
+const struct radio_encoder_ops radio_encoder_mp3 = {
+	.name = "mp3",
+#ifdef HAVE_LIBSHOUT
+	.shout_format = SHOUT_FORMAT_MP3,
+#else
+	.shout_format = 0,
+#endif
+	.init = mp3_encoder_init,
+	.destroy = mp3_encoder_destroy,
+	.encode_frame = mp3_encoder_encode_frame,
+	.flush = mp3_encoder_flush,
+	.max_output_for = mp3_encoder_max_output_for,
+};
+#else  /* !HAVE_LAME */
+static bool mp3_stub_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+			  size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(sample_rate);
+	UNUSED_PARAMETER(channels);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	obs_log(LOG_ERROR, "MP3 encoding not available — rebuild with libmp3lame");
+	return false;
+}
+static void mp3_stub_destroy(struct radio_output *context)
+{
+	UNUSED_PARAMETER(context);
+}
+static int mp3_stub_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+				 uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(left);
+	UNUSED_PARAMETER(right);
+	UNUSED_PARAMETER(frames);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return -1;
+}
+static int mp3_stub_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return 0;
+}
+static size_t mp3_stub_max_output_for(struct radio_output *context, size_t frames)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(frames);
+	return 0;
+}
+const struct radio_encoder_ops radio_encoder_mp3 = {
+	.name = "mp3",
+	.shout_format = 0,
+	.init = mp3_stub_init,
+	.destroy = mp3_stub_destroy,
+	.encode_frame = mp3_stub_encode_frame,
+	.flush = mp3_stub_flush,
+	.max_output_for = mp3_stub_max_output_for,
+};
 #endif /* HAVE_LAME */
 
 static bool radio_output_start(void *data)
@@ -322,52 +479,39 @@ static bool radio_output_start(void *data)
 			"SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server");
 	}
 
-	/* --- Initialize audio encoder --- */
-	if (context->codec == RADIO_CODEC_MP3) {
-#ifdef HAVE_LAME
-		struct obs_audio_info oai;
-		uint32_t sample_rate = 48000;
-		int lame_ch = 2; /* default stereo */
-		if (obs_get_audio_info(&oai))
-			sample_rate = oai.samples_per_sec;
+	/* --- Select + initialize encoder --- */
+	struct obs_audio_info oai;
+	context->sample_rate = 48000;
+	context->channels = 2;
+	if (obs_get_audio_info(&oai))
+		context->sample_rate = oai.samples_per_sec;
 
-		context->lame_gfp = lame_init();
-		if (!context->lame_gfp) {
-			obs_log(LOG_ERROR, "lame_init() failed");
-			obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
-			return false;
-		}
-		lame_set_in_samplerate(context->lame_gfp, (int)sample_rate);
-		lame_set_num_channels(context->lame_gfp, lame_ch);
-		lame_set_out_samplerate(context->lame_gfp, 0);
-		lame_set_brate(context->lame_gfp, context->bitrate);
-		lame_set_quality(context->lame_gfp, 2);
-		if (lame_init_params(context->lame_gfp) < 0) {
-			obs_log(LOG_ERROR, "lame_init_params() failed");
-			lame_close(context->lame_gfp);
-			context->lame_gfp = NULL;
-			obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
-			return false;
-		}
-		obs_log(LOG_INFO, "MP3 encoder: %u Hz, %d ch, %d kbps", sample_rate, lame_ch, context->bitrate);
-#else
-		obs_log(LOG_ERROR, "MP3 encoding not available — rebuild with libmp3lame");
+	switch (context->codec) {
+	case RADIO_CODEC_OPUS:
+		context->encoder = &radio_encoder_opus;
+		break;
+	case RADIO_CODEC_MP3:
+	default:
+		context->encoder = &radio_encoder_mp3;
+		break;
+	}
+
+	uint8_t *startup_bytes = NULL;
+	size_t startup_len = 0;
+	if (!context->encoder->init(context, context->sample_rate, context->channels, &startup_bytes, &startup_len)) {
+		/* init() cleans up its own partial state on failure. */
+		context->encoder = NULL;
 		obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
-#endif
 	}
-	/* RADIO_CODEC_OPUS: Ogg/Opus encoding tracked in feat/raw-audio-opus */
 
 	/* --- Configure libshout --- */
 	context->shout = shout_new();
 	if (!context->shout) {
 		obs_log(LOG_ERROR, "shout_new() failed (out of memory?)");
-#ifdef HAVE_LAME
-		if (context->lame_gfp) {
-			lame_close(context->lame_gfp);
-			context->lame_gfp = NULL;
-		}
-#endif
+		context->encoder->destroy(context);
+		context->encoder = NULL;
+		bfree(startup_bytes);
 		obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
 	}
@@ -382,12 +526,9 @@ static bool radio_output_start(void *data)
 		obs_log(LOG_ERROR, "shout_open() failed: %s", shout_get_error(context->shout));
 		shout_free(context->shout);
 		context->shout = NULL;
-#ifdef HAVE_LAME
-		if (context->lame_gfp) {
-			lame_close(context->lame_gfp);
-			context->lame_gfp = NULL;
-		}
-#endif
+		context->encoder->destroy(context);
+		context->encoder = NULL;
+		bfree(startup_bytes);
 		set_state(context, RADIO_STATE_ERROR);
 		obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
@@ -399,61 +540,54 @@ static bool radio_output_start(void *data)
 
 	if (!obs_output_begin_data_capture(context->output, 0)) {
 		obs_log(LOG_ERROR, "obs_output_begin_data_capture() failed");
-		shout_close(context->shout);
-		shout_free(context->shout);
-		context->shout = NULL;
-#ifdef HAVE_LAME
-		if (context->lame_gfp) {
-			lame_close(context->lame_gfp);
-			context->lame_gfp = NULL;
-		}
-#endif
-		set_state(context, RADIO_STATE_ERROR);
-		return false;
+		bfree(startup_bytes);
+		goto start_fail_after_open;
 	}
 
-#ifdef HAVE_LAME
-	if (context->codec == RADIO_CODEC_MP3) {
-		uint8_t *sbuf = bmalloc(SEND_BUF_CAPACITY);
-		if (!sbuf) {
-			obs_log(LOG_ERROR, "Failed to allocate MP3 send buffer");
-			goto start_fail_after_capture;
-		}
-		/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio. */
-		context->send_wpos = 0;
-		context->send_rpos = 0;
-		context->send_running = true;
-		pthread_mutex_init(&context->send_mutex, NULL);
-		pthread_cond_init(&context->send_cond, NULL);
-		context->send_buf = sbuf; /* raw_audio uses this as its "ready" gate */
-		if (pthread_create(&context->send_thread, NULL, mp3_send_thread, context) != 0) {
-			obs_log(LOG_ERROR, "Failed to create MP3 send thread");
-			context->send_running = false;
-			context->send_buf = NULL;
-			pthread_mutex_destroy(&context->send_mutex);
-			pthread_cond_destroy(&context->send_cond);
-			bfree(sbuf);
-			goto start_fail_after_capture;
-		}
-		obs_log(LOG_INFO, "MP3 send thread started");
+	/* --- Start shared send thread (all codecs) --- */
+	uint8_t *sbuf = bmalloc(SEND_BUF_CAPACITY);
+	if (!sbuf) {
+		obs_log(LOG_ERROR, "Failed to allocate send buffer");
+		bfree(startup_bytes);
+		goto start_fail_after_capture;
 	}
-#endif
+	/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio. */
+	context->send_wpos = 0;
+	context->send_rpos = 0;
+	context->send_running = true;
+	pthread_mutex_init(&context->send_mutex, NULL);
+	pthread_cond_init(&context->send_cond, NULL);
+	context->send_buf = sbuf; /* raw_audio uses this as its "ready" gate */
+	if (pthread_create(&context->send_thread, NULL, encoder_send_thread, context) != 0) {
+		obs_log(LOG_ERROR, "Failed to create encoder send thread");
+		context->send_running = false;
+		context->send_buf = NULL;
+		pthread_mutex_destroy(&context->send_mutex);
+		pthread_cond_destroy(&context->send_cond);
+		bfree(sbuf);
+		bfree(startup_bytes);
+		goto start_fail_after_capture;
+	}
+	obs_log(LOG_INFO, "Encoder send thread started (codec=%s)", context->encoder->name);
+
+	/* Queue container startup bytes (Opus: OpusHead + OpusTags pages) so
+	 * the send thread ships them before any audio.  MP3 has none. */
+	if (startup_bytes && startup_len > 0)
+		send_buf_push(context, startup_bytes, startup_len);
+	bfree(startup_bytes);
 
 	return true;
 
-#ifdef HAVE_LAME
 start_fail_after_capture:
 	obs_output_end_data_capture(context->output);
+start_fail_after_open:
 	shout_close(context->shout);
 	shout_free(context->shout);
 	context->shout = NULL;
-	if (context->lame_gfp) {
-		lame_close(context->lame_gfp);
-		context->lame_gfp = NULL;
-	}
+	context->encoder->destroy(context);
+	context->encoder = NULL;
 	set_state(context, RADIO_STATE_ERROR);
 	return false;
-#endif
 #endif
 }
 
@@ -474,49 +608,28 @@ static void radio_output_raw_audio(void *data, struct audio_data *frames)
 	if (!frames || !frames->frames)
 		return;
 
-	if (context->codec == RADIO_CODEC_MP3) {
-#ifdef HAVE_LAME
-		if (!context->lame_gfp || !context->send_buf)
-			return;
+	/* send_buf doubles as the "ready to write" gate — set by start() only
+	 * after mutex/cond/send thread are all live.  encoder is set one step
+	 * earlier, so both null-checks matter. */
+	if (!context->encoder || !context->send_buf)
+		return;
 
-		const float *left = (const float *)frames->data[0];
-		const float *right = frames->data[1] ? (const float *)frames->data[1] : left;
+	const float *left = (const float *)frames->data[0];
+	const float *right = frames->data[1] ? (const float *)frames->data[1] : left;
 
-		/* Upper bound from LAME docs: 1.25 * nsamples + 7200 bytes. */
-		int buf_size = (int)(1.25f * (float)frames->frames) + 7200;
-		uint8_t *mp3buf = bmalloc((size_t)buf_size);
+	size_t cap = context->encoder->max_output_for(context, frames->frames);
+	if (cap < 4096)
+		cap = 4096;
+	uint8_t *buf = bmalloc(cap);
 
-		int mp3_bytes = lame_encode_buffer_ieee_float(context->lame_gfp, left, right, (int)frames->frames,
-							      mp3buf, buf_size);
-
-		if (mp3_bytes > 0) {
-			pthread_mutex_lock(&context->send_mutex);
-			/* Drop oldest data if the ring buffer is full. */
-			size_t used = context->send_wpos - context->send_rpos;
-			if (used + (size_t)mp3_bytes > SEND_BUF_CAPACITY) {
-				size_t drop = used + (size_t)mp3_bytes - SEND_BUF_CAPACITY;
-				context->send_rpos += drop;
-				obs_log(LOG_WARNING, "send buffer full, dropped %zu bytes", drop);
-			}
-			size_t wpos = context->send_wpos % SEND_BUF_CAPACITY;
-			size_t tail = SEND_BUF_CAPACITY - wpos;
-			if (tail >= (size_t)mp3_bytes) {
-				memcpy(context->send_buf + wpos, mp3buf, (size_t)mp3_bytes);
-			} else {
-				memcpy(context->send_buf + wpos, mp3buf, tail);
-				memcpy(context->send_buf, mp3buf + tail, (size_t)mp3_bytes - tail);
-			}
-			context->send_wpos += (size_t)mp3_bytes;
-			pthread_cond_signal(&context->send_cond);
-			pthread_mutex_unlock(&context->send_mutex);
-		} else if (mp3_bytes < 0) {
-			obs_log(LOG_ERROR, "lame_encode_buffer_ieee_float() error: %d", mp3_bytes);
-		}
-
-		bfree(mp3buf);
-#endif /* HAVE_LAME */
+	int bytes = context->encoder->encode_frame(context, left, right, (size_t)frames->frames, buf, cap);
+	if (bytes > 0) {
+		send_buf_push(context, buf, (size_t)bytes);
+	} else if (bytes < 0) {
+		obs_log(LOG_ERROR, "[%s] encode_frame error: %d", context->encoder->name, bytes);
 	}
-	/* RADIO_CODEC_OPUS: Ogg/Opus encoding tracked in feat/raw-audio-opus */
+
+	bfree(buf);
 #endif /* HAVE_LIBSHOUT */
 }
 

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -397,6 +397,16 @@ static size_t mp3_encoder_max_output_for(struct radio_output *context, size_t fr
 	return (size_t)(1.25f * (float)frames) + 7200;
 }
 
+static int mp3_encoder_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	/* MP3 is frame-synced — decoders resync on the next frame header.  No
+	 * container metadata to re-emit; the LAME encoder keeps its state. */
+	*out_headers = NULL;
+	*out_bytes = 0;
+	return 0;
+}
+
 const struct radio_encoder_ops radio_encoder_mp3 = {
 	.name = "mp3",
 #ifdef HAVE_LIBSHOUT
@@ -409,6 +419,7 @@ const struct radio_encoder_ops radio_encoder_mp3 = {
 	.encode_frame = mp3_encoder_encode_frame,
 	.flush = mp3_encoder_flush,
 	.max_output_for = mp3_encoder_max_output_for,
+	.on_reconnect = mp3_encoder_on_reconnect,
 };
 #else  /* !HAVE_LAME */
 static bool mp3_stub_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
@@ -450,6 +461,13 @@ static size_t mp3_stub_max_output_for(struct radio_output *context, size_t frame
 	UNUSED_PARAMETER(frames);
 	return 0;
 }
+static int mp3_stub_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	return 0;
+}
 const struct radio_encoder_ops radio_encoder_mp3 = {
 	.name = "mp3",
 	.shout_format = 0,
@@ -458,6 +476,7 @@ const struct radio_encoder_ops radio_encoder_mp3 = {
 	.encode_frame = mp3_stub_encode_frame,
 	.flush = mp3_stub_flush,
 	.max_output_for = mp3_stub_max_output_for,
+	.on_reconnect = mp3_stub_on_reconnect,
 };
 #endif /* HAVE_LAME */
 

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -28,6 +28,9 @@ typedef enum {
 	RADIO_STATE_ERROR,
 } radio_state_t;
 
+/* Forward-declared; the full struct lives in radio-encoder.h. */
+struct radio_encoder_ops;
+
 struct radio_output {
 	obs_output_t *output; // back-pointer to OBS output object
 #ifdef HAVE_LIBSHOUT
@@ -46,6 +49,23 @@ struct radio_output {
 	int codec; // RADIO_CODEC_OPUS, RADIO_CODEC_MP3, etc.
 	int bitrate;
 
+	/* Codec dispatch.  Selected in radio_output_start() from the codec id
+	 * (RADIO_CODEC_MP3 / RADIO_CODEC_OPUS).  NULL means no encoder is
+	 * currently active — raw_audio must bail. */
+	const struct radio_encoder_ops *encoder;
+
+	/* Opaque per-encoder state.  Ownership lives with the encoder:
+	 * radio_encoder_ops->init allocates it, ->destroy frees it.  MP3 uses
+	 * lame_gfp instead (historical), so this is only populated by Opus
+	 * today.  Do not touch from outside an encoder callback. */
+	void *encoder_priv;
+
+	/* Ambient samplerate at stream start (Hz).  Set in radio_output_start
+	 * from obs_get_audio_info; used by shout_apply_settings for
+	 * SHOUT_AI_SAMPLERATE. */
+	uint32_t sample_rate;
+	int channels; /* 1 or 2 */
+
 	// Runtime state
 	radio_state_t state;
 	pthread_mutex_t state_mutex;
@@ -63,8 +83,15 @@ struct radio_output {
 
 #ifdef HAVE_LAME
 	lame_global_flags *lame_gfp; /* LAME MP3 encoder handle — NULL when inactive */
+#endif
 
-	/* MP3 sender thread — encodes in raw_audio, sends + syncs here */
+#ifdef HAVE_LIBSHOUT
+	/*
+	 * Shared sender thread.  The encoder writes compressed bytes into
+	 * send_buf from the audio thread; this thread drains them to libshout
+	 * with shout_sync() pacing.  Originally MP3-only (hence the naming in
+	 * older logs); now generic across MP3 and Opus.
+	 */
 #define SEND_BUF_CAPACITY (256 * 1024) /* 256 KB ≈ 14 s at 128 kbps */
 	uint8_t *send_buf;
 	size_t send_wpos; /* monotonically increasing write position */

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "reconnect.h"
+#include "radio-encoder.h"
 
 #include <plugin-support.h>
 #include <util/platform.h>
+#include <util/bmem.h>
 
 /* -------------------------------------------------------------------------
  * Internal helpers (libshout builds only)
@@ -33,6 +35,39 @@ static bool attempt_connect(struct radio_output *context)
 		obs_log(LOG_WARNING, "[reconnect] shout_open() failed: %s", shout_get_error(shout));
 		shout_free(shout);
 		return false;
+	}
+
+	/*
+	 * Ask the encoder to re-emit any container startup headers and push
+	 * them on the fresh connection BEFORE making context->shout visible
+	 * to the send thread.  Without this, Icecast sees data pages on the
+	 * new source with no BOS/OpusHead and cannot serve listeners (the
+	 * previous mount's cached headers are released when the old source
+	 * disconnects).
+	 *
+	 * Headers go out via shout_send directly rather than send_buf_push +
+	 * the send thread because the send thread would drop them while
+	 * context->shout is still NULL, and flipping the order (publish
+	 * shout, then push headers) lets the send thread ship mid-stream
+	 * audio from the audio thread before the headers.
+	 */
+	if (context->encoder && context->encoder->on_reconnect) {
+		uint8_t *hdrs = NULL;
+		size_t hdr_len = 0;
+		if (context->encoder->on_reconnect(context, &hdrs, &hdr_len) < 0) {
+			obs_log(LOG_ERROR, "[reconnect] encoder header re-emit failed for codec %s",
+				context->encoder->name);
+			/* fall through — keep the connection and cross fingers; a clean
+			 * failure mode would be to shout_close + retry, but that risks
+			 * an infinite loop if the encoder is persistently broken. */
+		} else if (hdrs && hdr_len > 0) {
+			int hdr_ret = shout_send(shout, hdrs, hdr_len);
+			if (hdr_ret != SHOUTERR_SUCCESS) {
+				obs_log(LOG_WARNING, "[reconnect] shout_send() for container headers failed: %s",
+					shout_get_error(shout));
+			}
+		}
+		bfree(hdrs);
 	}
 
 	context->shout = shout;


### PR DESCRIPTION
## Summary

- Introduces a codec vtable (`struct radio_encoder_ops` in `src/radio-encoder.h`) so `radio-output.c` dispatches MP3 and Opus paths through one interface instead of hardcoding codec checks.
- Wires up the Opus encoder — libopus for compression, libogg for container framing — in a new `src/radio-opus-encoder.c`. Emits OpusHead + OpusTags on stream start, wraps 20 ms Opus packets in Ogg pages, terminates with an EOS page at teardown.
- **Reconnect under Opus re-emits container headers** — added `on_reconnect` vtable hook so the Ogg stream resets (new serial, packet counters back to 0) and OpusHead + OpusTags are shipped on every reconnection. Without this, Icecast sees mid-stream data pages on the new source connection and listeners can't decode. MP3 is frame-synced, so its `on_reconnect` is a no-op.
- Refactors the existing LAME MP3 path into vtable shims (`mp3_encoder_init`, `_encode_frame`, `_flush`, `_destroy`, `_max_output_for`, `_on_reconnect`) so MP3 behavior is unchanged from the caller's perspective.
- The shared ring buffer + send thread (formerly MP3-only, named `mp3_send_thread`) is now codec-agnostic and renamed `encoder_send_thread`.

Closes #29 (§C.2 codec abstraction) and #30 (§C.3 Opus encoder).

## Design notes

- **MP3 code stays inline in `radio-output.c`.** The goal was minimum churn for a codec that already worked; the vtable wraps what was there, no behavior changes.
- **Opus encoder requires 48 kHz input** and fails init with a clear log line if OBS is at a different sample rate. 48 kHz is OBS's default and the native Opus clock rate; resampling is out of scope for this PR.
- **Stereo path uses channel mapping family 0** (standard for mono/stereo Opus). Mono downmix averages L+R so we don't drop half the signal if a mono output type is added later.
- **Ogg pagination**: `ogg_stream_pageout` during audio (≈4 KB page granularity → ~250 ms of buffering, negligible against our 14 s ring buffer), `ogg_stream_flush` at teardown to force final pages + EOS.
- **Opus encoder settings**: `OPUS_APPLICATION_AUDIO`, `OPUS_SIGNAL_MUSIC`, `OPUS_SET_COMPLEXITY(10)`, `OPUS_SET_VBR(1)`. Bitrate comes from the existing `SETTING_BITRATE` in kbps, multiplied by 1000 for Opus.
- **Reconnect header re-emit timing:** headers ship via `shout_send` directly from the reconnect thread BEFORE `context->shout` is made visible to the send thread. This avoids a race where the audio thread's next `encode_frame` → `send_buf_push` could ship data packets on the new connection ahead of the container headers.
- **Encoder state preserved across reconnect**: only the Ogg container resets. The `OpusEncoder`'s perceptual state (pitch predictor, LPC residuals) and the partial-frame PCM accumulator survive — preserves audio continuity, loses only the container framing that has to be fresh for a new Icecast source connection.
- **SHOUTcast v1 + Opus still warns loudly at start** (existing guard in `radio_output_start`) — ICY protocol only carries MP3.

## Test plan

### Prereq

- Pull this branch: `git fetch origin feat/raw-audio-opus && git checkout feat/raw-audio-opus`
- Build: `./build-and-install-macos.sh`
- Relaunch OBS. Look for `[obs-radio-output] plugin loaded successfully` in `~/Library/Application Support/obs-studio/logs/<current>.txt`.

### Test 1 — MP3 regression (no behavior change) — ✅ PASS

1. Open Tools → Radio Output… → configure Icecast mount, Codec=MP3, Bitrate=128, Protocol=Icecast.
2. Click Start in the Radio Output dock.
3. Tune in on a player (VLC / Icecast's test stream page).
4. Expect logs:
   - [x] `MP3 encoder: 48000 Hz, 2 ch, 128 kbps` ✅
   - [x] `Connected to <host>:<port><mount>` ✅
   - [x] `Encoder send thread started (codec=mp3)` ✅ ← new log line, was "MP3 send thread started"
5. [x] Confirm audio plays normally in the player for 30 seconds. ✅ **"sound works on both tests" — Aaron**
6. Click Stop. Expect:
   - [x] `Encoder send thread stopped` ✅
   - [x] `Disconnected from <host>:<port><mount>` ✅ (single log — PR #21's double-log fix holds)
7. **Pass criteria**: audio plays identically to main; no warnings; no crashes. ✅ PASS

**Evidence (2026-04-22):**
```
21:16:43.114: [obs-radio-output] MP3 encoder: 48000 Hz, 2 ch, 128 kbps
21:16:43.542: [obs-radio-output] Connected to localhost:8000/stream
21:16:43.542: [obs-radio-output] Encoder send thread started (codec=mp3)
21:17:27.221: [obs-radio-output] Encoder send thread stopped
21:17:27.223: [obs-radio-output] Disconnected from localhost:8000/stream
```
Stream duration: 44 s. Connect latency: 428 ms. Stop-to-disconnect: 2 ms. No warnings, no errors.

### Test 2 — Opus happy path (Icecast) — ✅ PASS

1. Same server, change Codec=Opus, Bitrate=96. Leave Protocol=Icecast.
2. Click Start.
3. Expect logs:
   - [x] `Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312` ✅ (pre-skip 312 is libopus complexity-10 default)
   - [x] `Connected to <host>:<port><mount>` ✅
   - [x] `Encoder send thread started (codec=opus)` ✅ — vtable dispatch confirmed
4. [x] Tune in with VLC. Stream should be listed as `audio/ogg` or `application/ogg` and decode as Opus. ✅
5. [x] Verify audio plays cleanly for 30 seconds — no clicks, no skipped samples. ✅ **"sound works on both tests" — Aaron**
6. Click Stop. Expect:
   - [x] `Encoder send thread stopped` ✅
   - [x] `Disconnected from <host>:<port><mount>` ✅
7. **Pass criteria**: Opus stream plays back cleanly in VLC; Icecast status page shows content type `application/ogg`; no encoder errors in log. ✅ PASS

**Evidence (2026-04-22):**
```
21:20:30.162: [obs-radio-output] Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312
21:20:30.654: [obs-radio-output] Connected to localhost:8000/stream
21:20:30.654: [obs-radio-output] Encoder send thread started (codec=opus)
21:21:07.985: [obs-radio-output] Encoder send thread stopped
21:21:07.985: [obs-radio-output] Disconnected from localhost:8000/stream
```
Stream duration: 37 s. Connect latency: 492 ms. Stop-to-disconnect: instant.

**Icecast admin readout** confirms Ogg + Opus container is correct:
- `server_type: audio/ogg` ✅ — `shout_set_content_format(SHOUT_FORMAT_OGG, ...)` taking
- `subtype: Opus` ✅ — **Icecast parsed our OpusHead page and identified the codec.** Strong evidence that the 19-byte OpusHead layout (RFC 7845 §5.1) is byte-correct; a malformed OpusHead would leave subtype empty or wrong.
- `audio_info: bitrate=96;samplerate=48000;channels=2` ✅ — matches config
- `user_agent: obs-radio-output/0.1.0` ✅ — `shout_set_agent` working
- `total_bytes_read: 46404` ✅ — data flowing from source to Icecast

### Test 3 — Opus rejects non-48 kHz — ✅ PASS

1. OBS → Settings → Audio → Sample Rate = 44.1 kHz. Save + relaunch OBS.
2. Tools → Radio Output… → Codec=Opus, click Start.
3. [x] Expect error log: `Opus requires 48 kHz audio; OBS is at 44100 Hz (change in Settings → Audio → Sample Rate)` ✅ — verbatim
4. [x] Expect the stream to NOT start; state returns to Disconnected. ✅
5. Restore OBS to 48 kHz before moving on.
6. **Pass criteria**: clean error, no crash, state rolls back to Disconnected. ✅ PASS

**Evidence (2026-04-22):**
```
21:23:28.310: [obs-radio-output] Opus requires 48 kHz audio; OBS is at 44100 Hz (change in Settings → Audio → Sample Rate)
21:23:28.310: [obs-radio-output] [frontend-wire] obs_output_start failed
```
`opus_init` returned false → `radio_output_start` signalled `OBS_OUTPUT_CONNECT_FAILED` → frontend-wire caught the failed start. No hang, no crash.

### Test 4 — Reconnect still works under Opus — ✅ PASS (after fix commit)

**Bug caught first time around (commit `d1c1ab0`):** reconnect mechanism reconnected cleanly and bytes flowed to Icecast, but VLC couldn't decode post-reconnect because `OpusHead` was not re-emitted on the fresh source connection. **Fix landed in commit `8356248`** — `on_reconnect` vtable hook re-initializes the Ogg stream and ships fresh container headers.

1. Codec=Opus, Reconnect=enabled, max retries=5, delay=3s.
2. Start streaming.
3. Kill the Icecast container (`docker stop icecast`).
4. [x] Expect `[send-thread] shout_send() failed:` then `[reconnect] reconnect thread started ...` in the log. ✅
5. Restart Icecast within the reconnect window. Expect:
   - [x] `[reconnect] reconnected to <host>:<port><mount>` ✅
   - [x] **`[opus] re-emitted Ogg container headers after reconnect (<N> bytes, serial 0x<hex>)`** ✅ ← fix confirmation
6. [x] Verify the player automatically resumes audio without a plugin Stop→Start cycle. ✅ **"that works!" — Aaron**
7. [x] Retry multiple times — rapid reconnect epochs produce different serials. ✅ — 2 consecutive reconnects captured in one session with **distinct serials** (`0xb95ad09b` then `0x1b035a6a`)
8. **Pass criteria**: audio resumes after reconnect without plugin Stop+Start cycle; no malformed-Ogg errors from VLC; `[opus] re-emitted Ogg container headers …` in log on every reconnect. ✅ PASS

**Evidence (2026-04-22) — two reconnect cycles in one session:**
```
21:47:33.717: [obs-radio-output] Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312
21:47:34.329: [obs-radio-output] Connected to localhost:8000/stream
21:47:34.330: [obs-radio-output] Encoder send thread started (codec=opus)
21:48:03.846: [obs-radio-output] [send-thread] shout_send() failed: Socket error
21:48:03.846: [obs-radio-output] [reconnect] reconnect thread started (delay 3000 ms, max 5 retries)
21:48:06.934: [obs-radio-output] [reconnect] attempt 1/5 to localhost:8000/stream ...
21:48:06.935: [obs-radio-output] [reconnect] shout_open() failed: Couldn't connect
21:48:10.029: [obs-radio-output] [reconnect] attempt 2/5 to localhost:8000/stream ...
21:48:10.445: [obs-radio-output] [opus] re-emitted Ogg container headers after reconnect (107 bytes, serial 0xb95ad09b)
21:48:10.445: [obs-radio-output] [reconnect] reconnected to localhost:8000/stream
21:48:30.918: [obs-radio-output] [send-thread] shout_send() failed: Socket error
21:48:30.918: [obs-radio-output] [reconnect] reconnect thread started (delay 3000 ms, max 5 retries)
21:48:34.027: [obs-radio-output] [reconnect] attempt 1/5 to localhost:8000/stream ...
21:48:34.029: [obs-radio-output] [reconnect] shout_open() failed: Couldn't connect
21:48:37.107: [obs-radio-output] [reconnect] attempt 2/5 to localhost:8000/stream ...
21:48:37.109: [obs-radio-output] [reconnect] shout_open() failed: Couldn't connect
21:48:40.217: [obs-radio-output] [reconnect] attempt 3/5 to localhost:8000/stream ...
21:48:40.640: [obs-radio-output] [opus] re-emitted Ogg container headers after reconnect (107 bytes, serial 0x1b035a6a)
21:48:40.640: [obs-radio-output] [reconnect] reconnected to localhost:8000/stream
21:48:54.707: [obs-radio-output] [reconnect] reconnect thread stopped
21:48:54.707: [obs-radio-output] Encoder send thread stopped
21:48:54.707: [obs-radio-output] Disconnected from localhost:8000/stream
```

**Measurements:**
- **Reconnect #1:** 6.6 s downtime, succeeded on attempt 2/5, emitted **107 bytes** at serial `0xb95ad09b`.
- **Reconnect #2** (back-to-back, same session): 9.7 s downtime, succeeded on attempt 3/5, emitted **107 bytes** at serial `0x1b035a6a` — **distinct serial** confirms the reconnect-epoch counter prevents collisions on rapid reconnects.
- **Byte math checks out:** OpusHead (19) + OpusTags (8 + 4 + 16 + 4 = 32) + two Ogg page overheads (27 + 1 = 28 each) = **107 bytes exact**. RFC 7845 §5.1 / §5.2 layouts byte-correct.
- **Clean stop at end:** single `Disconnected` log; reconnect and send threads both joined; no residual state.

### Test 5 — SHOUTcast v1 + Opus warns — ✅ PASS

Run against the local Icecast server (which doesn't speak ICY source protocol) as a proxy for "server rejects the combination" — the acceptance criterion is that **our warning fires BEFORE `shout_open`**, not that a real SHOUTcast DNAS server rejects the stream. Running a real SHOUTcast DNAS for this is deferred to §I acceptance testing once fixture work is done.

1. Codec=Opus, Protocol=SHOUTcast v1, Host=localhost:8000 (Icecast — intentional mis-match).
2. Click Start.
3. [x] Warning log appears FIRST, before encoder init or shout_open: `SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server` ✅
4. [x] Connection fails cleanly. ✅ — **libshout itself rejected the SHOUT_PROTOCOL_ICY + SHOUT_FORMAT_OGG combination client-side** (`shout_open() failed: This libshout doesn't support the requested option`). Never even opened a TCP connection — libshout 2.4.6 has a client-side guard against the incompatible combo. More robust than the test plan assumed.
5. **Pass criteria**: warning appears BEFORE the connect attempt; either connect fails gracefully or the server rejects with a shout_open error. ✅ PASS

**Evidence (2026-04-22):**
```
22:23:37.400: [obs-radio-output] SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server
22:23:37.400: [obs-radio-output] Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312
22:23:37.400: [obs-radio-output] shout_open() failed: This libshout doesn't support the requested option
22:23:37.400: [obs-radio-output] [frontend-wire] obs_output_start failed
22:23:37.400: [obs-radio-output] Disconnected from localhost:8000/stream
```

**Observations:**
- All five lines logged in the same millisecond — no hang, no crash, clean rollback.
- **Ordering is correct**: warning fires at the top of `radio_output_start` before the encoder init path, which was the specific thing this test was designed to verify.
- **Bonus finding**: libshout's own client-side guard saves us a network round-trip. A real SHOUTcast DNAS server never sees the bytes — the failure is caught at `shout_open` before socket connect. Either libshout path (unsupported option) or a real server rejection would satisfy the pass criterion.

### CI pass criteria — ✅ ALL GREEN (on fix commit 8356248)

- [x] macOS build succeeds (Universal 2, libopus + libogg linked)
- [x] Windows build skips Opus (libopus/libogg not on vcpkg yet — stub path)
- [x] Ubuntu build succeeds (libopus-dev + libogg-dev from apt)
- [x] clang-tidy passes (reviewdog: neutral — no findings)
- [x] pre-commit / clang-format / gersemi clean
- [x] CodeQL passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


