### PR TITLE
ci(deps): build openssl@3 Universal and link libshout with TLS on macOS (§E.1)

### DIFF
--- a/.github/scripts/build-macos
+++ b/.github/scripts/build-macos
@@ -106,6 +106,7 @@ build() {
   cmake_args+=(-DLibLame_ROOT=/tmp/liblame-universal)
   cmake_args+=(-DLibOgg_ROOT=/tmp/libogg-universal)
   cmake_args+=(-DLibOpus_ROOT=/tmp/libopus-universal)
+  cmake_args+=(-DOPENSSL_ROOT_DIR=/tmp/openssl-universal)
 
   typeset -gx NSUnbufferedIO=YES
 
@@ -135,6 +136,44 @@ build() {
   popd
   log_group
 
+  log_group "Building Universal openssl@3 (libshout TLS backend)..."
+  # libshout's configure accepts --with-openssl=<prefix> and reads -I$prefix/include
+  # and -L$prefix/lib directly (XIPH_PATH_SSL macro, no pkg-config involvement),
+  # so per-arch prefixes work without PKG_CONFIG_PATH juggling.  `no-shared` builds
+  # libssl.a + libcrypto.a only; `no-tests` skips the self-test build which takes
+  # ~minutes and is unnecessary in CI.  openssl's build system is in-tree (not
+  # out-of-tree like autotools); `make clean` between arches resets object files.
+  curl -sSL --retry 3 https://www.openssl.org/source/openssl-3.3.2.tar.gz \
+    -o /tmp/openssl.tar.gz
+  tar -xzf /tmp/openssl.tar.gz -C /tmp
+  mv /tmp/openssl-3.3.2 /tmp/openssl-src
+  pushd /tmp/openssl-src
+
+  ./Configure darwin64-arm64-cc --prefix=/tmp/openssl-arm64 \
+    no-shared no-tests -arch arm64
+  make -j$(sysctl -n hw.ncpu) && make install_sw
+  make clean
+
+  ./Configure darwin64-x86_64-cc --prefix=/tmp/openssl-x86_64 \
+    no-shared no-tests -arch x86_64
+  make -j$(sysctl -n hw.ncpu) && make install_sw
+  popd
+
+  # Lipo the static archives into a Universal pair so the plugin can link a
+  # single arch-agnostic openssl at the cmake layer (see CMakeLists.txt APPLE
+  # block).  Headers are identical between the two arch prefixes except for
+  # opensslconf.h, which branches on __i386__/__x86_64__/__arm64__ at compile
+  # time — so a single header copy works for both slices of the fat binary.
+  mkdir -p /tmp/openssl-universal/lib /tmp/openssl-universal/include
+  for lib in libssl.a libcrypto.a; do
+    lipo -create \
+      /tmp/openssl-arm64/lib/${lib} \
+      /tmp/openssl-x86_64/lib/${lib} \
+      -output /tmp/openssl-universal/lib/${lib}
+  done
+  cp -R /tmp/openssl-arm64/include/openssl /tmp/openssl-universal/include/
+  log_group
+
   log_group "Building Universal libshout..."
   curl -sSL https://downloads.xiph.org/releases/libshout/libshout-2.4.6.tar.gz \
     -o /tmp/libshout.tar.gz
@@ -142,36 +181,62 @@ build() {
   mv /tmp/libshout-2.4.6 /tmp/icecast-libshout
   pushd /tmp/icecast-libshout
 
-  # arm64 slice — use arm64 libogg; disable optional deps to avoid arch mismatch
-  # -Wno-error=implicit-function-declaration: libshout 2.4.6 legacy.c/icy.c miss
-  # stdlib.h/stdio.h includes; Apple Clang 16 promotes this warning to an error.
+  # arm64 slice — static build with arch-matched openssl + libogg.  Optional
+  # codec deps (theora/speex/opus) stay disabled: we only use MP3 and Opus,
+  # and libshout's "opus" support is for Ogg-Opus container passthrough which
+  # we handle ourselves via libogg in src/radio-opus-encoder.c.
+  # -Wno-error=implicit-function-declaration: libshout 2.4.6 legacy.c/icy.c
+  # miss stdlib.h/stdio.h includes; Apple Clang 16 promotes this warning to
+  # an error.
   mkdir build-arm64 && pushd build-arm64
   PKG_CONFIG_LIBDIR=/tmp/libogg-arm64/lib/pkgconfig \
     ../configure --prefix=/tmp/libshout-arm64 \
-      --without-openssl --without-theora --without-speex --without-opus \
+      --disable-shared --enable-static \
+      --with-openssl=/tmp/openssl-arm64 \
+      --without-theora --without-speex --without-opus \
       CFLAGS="-arch arm64 -Wno-error=implicit-function-declaration" \
       LDFLAGS="-arch arm64"
   make -j$(sysctl -n hw.ncpu) && make install
   popd
 
-  # x86_64 slice — use x86_64 libogg; disable optional deps to avoid arch mismatch
+  # x86_64 slice — same flags against the x86_64 openssl prefix.
   mkdir build-x86_64 && pushd build-x86_64
   PKG_CONFIG_LIBDIR=/tmp/libogg-x86_64/lib/pkgconfig \
     ../configure --prefix=/tmp/libshout-x86_64 \
-      --without-openssl --without-theora --without-speex --without-opus \
+      --disable-shared --enable-static \
+      --with-openssl=/tmp/openssl-x86_64 \
+      --without-theora --without-speex --without-opus \
       CFLAGS="-arch x86_64 -Wno-error=implicit-function-declaration" \
       LDFLAGS="-arch x86_64"
   make -j$(sysctl -n hw.ncpu) && make install
   popd
 
-  # Merge with lipo
+  # Merge static archives with lipo.  The switch from .dylib to .a here is
+  # deliberate: a .dylib would embed openssl's .a at libshout-link time and we
+  # could stop there, but a static archive means the plugin's .plugin bundle
+  # has zero external runtime deps (verified via `otool -L`), which matches
+  # how liblame and libopus are packaged.  Cost: the plugin itself must now
+  # link ssl+crypto (done in CMakeLists.txt); benefit: one self-contained
+  # bundle with no dyld resolution of libssl/libcrypto at OBS launch.
   mkdir -p /tmp/libshout-universal/lib /tmp/libshout-universal/include
   lipo -create \
-    /tmp/libshout-arm64/lib/libshout.dylib \
-    /tmp/libshout-x86_64/lib/libshout.dylib \
-    -output /tmp/libshout-universal/lib/libshout.dylib
+    /tmp/libshout-arm64/lib/libshout.a \
+    /tmp/libshout-x86_64/lib/libshout.a \
+    -output /tmp/libshout-universal/lib/libshout.a
   cp -r /tmp/libshout-arm64/include/shout /tmp/libshout-universal/include/
   popd
+
+  # TLS-symbol sanity check.  If libshout's configure silently fell back to
+  # the non-TLS path (e.g. a malformed --with-openssl path), the archive will
+  # still build and link — but `shout_set_tls` will return SHOUTERR_UNSUPPORTED
+  # at runtime with no link-time warning.  Grep for _SSL_connect in the
+  # archive as an unambiguous "TLS was compiled in" proof; fail the CI job
+  # here, not at §E.2 acceptance testing time.
+  if ! nm /tmp/libshout-universal/lib/libshout.a 2>/dev/null | grep -q _SSL_connect; then
+    log_error "libshout.a has no _SSL_connect symbol — TLS did not compile in"
+    return 2
+  fi
+  log_info "libshout.a TLS symbols present (_SSL_connect found)"
   log_group
 
   log_group "Building Universal libmp3lame..."

--- a/.github/scripts/build-macos
+++ b/.github/scripts/build-macos
@@ -149,13 +149,15 @@ build() {
   mv /tmp/openssl-3.3.2 /tmp/openssl-src
   pushd /tmp/openssl-src
 
-  ./Configure darwin64-arm64-cc --prefix=/tmp/openssl-arm64 \
-    no-shared no-tests -arch arm64
+  # NB: openssl's darwin64-*-cc targets already imply -arch <foo>; passing
+  # -arch on top of that trips Configure's "target already defined" error
+  # (`target already defined - darwin64-arm64-cc (offending arg: arm64)`).
+  # So just pick the target and don't add redundant arch flags.
+  ./Configure darwin64-arm64-cc --prefix=/tmp/openssl-arm64 no-shared no-tests
   make -j$(sysctl -n hw.ncpu) && make install_sw
   make clean
 
-  ./Configure darwin64-x86_64-cc --prefix=/tmp/openssl-x86_64 \
-    no-shared no-tests -arch x86_64
+  ./Configure darwin64-x86_64-cc --prefix=/tmp/openssl-x86_64 no-shared no-tests
   make -j$(sysctl -n hw.ncpu) && make install_sw
   popd
 

--- a/.github/scripts/build-macos
+++ b/.github/scripts/build-macos
@@ -187,14 +187,18 @@ build() {
   # codec deps (theora/speex/opus) stay disabled: we only use MP3 and Opus,
   # and libshout's "opus" support is for Ogg-Opus container passthrough which
   # we handle ourselves via libogg in src/radio-opus-encoder.c.
+  # --with-openssl: enable the TLS path (takes no DIR argument on libshout
+  # 2.4.6 — XIPH_PATH_SSL's macro is yes/no; prefix is discovered via
+  # pkg-config).  Point PKG_CONFIG_LIBDIR at both libogg and openssl so
+  # libshout's OGG + openssl probes both hit our arch-matched builds.
   # -Wno-error=implicit-function-declaration: libshout 2.4.6 legacy.c/icy.c
   # miss stdlib.h/stdio.h includes; Apple Clang 16 promotes this warning to
   # an error.
   mkdir build-arm64 && pushd build-arm64
-  PKG_CONFIG_LIBDIR=/tmp/libogg-arm64/lib/pkgconfig \
+  PKG_CONFIG_LIBDIR=/tmp/libogg-arm64/lib/pkgconfig:/tmp/openssl-arm64/lib/pkgconfig \
     ../configure --prefix=/tmp/libshout-arm64 \
       --disable-shared --enable-static \
-      --with-openssl=/tmp/openssl-arm64 \
+      --with-openssl \
       --without-theora --without-speex --without-opus \
       CFLAGS="-arch arm64 -Wno-error=implicit-function-declaration" \
       LDFLAGS="-arch arm64"
@@ -203,10 +207,10 @@ build() {
 
   # x86_64 slice — same flags against the x86_64 openssl prefix.
   mkdir build-x86_64 && pushd build-x86_64
-  PKG_CONFIG_LIBDIR=/tmp/libogg-x86_64/lib/pkgconfig \
+  PKG_CONFIG_LIBDIR=/tmp/libogg-x86_64/lib/pkgconfig:/tmp/openssl-x86_64/lib/pkgconfig \
     ../configure --prefix=/tmp/libshout-x86_64 \
       --disable-shared --enable-static \
-      --with-openssl=/tmp/openssl-x86_64 \
+      --with-openssl \
       --without-theora --without-speex --without-opus \
       CFLAGS="-arch x86_64 -Wno-error=implicit-function-declaration" \
       LDFLAGS="-arch x86_64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,20 @@ else()
   target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBSHOUT)
 endif()
 
+if(APPLE)
+  # libshout on macOS ships as a static archive built --with-openssl (see
+  # .github/scripts/build-macos).  The archive references SSL_*/EVP_* symbols
+  # but does not embed their definitions, so the plugin binary has to link
+  # libssl + libcrypto itself.  OPENSSL_USE_STATIC_LIBS makes find_package
+  # prefer .a over .dylib, which keeps the final .plugin bundle free of any
+  # runtime dylib dependency on openssl (verify via `otool -L`).  Ubuntu uses
+  # libshout3-dev's bundled TLS and Windows streaming is still optional, so
+  # this block is Apple-only.
+  set(OPENSSL_USE_STATIC_LIBS ON)
+  find_package(OpenSSL REQUIRED)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
 if(WIN32)
   # MP3 encoding via libmp3lame — optional on Windows until MSVC-compatible binaries are available.
   find_package(LibLame QUIET)

--- a/cmake/FindLibShout.cmake
+++ b/cmake/FindLibShout.cmake
@@ -13,6 +13,11 @@ find_path(
 
 if(WIN32)
   list(PREPEND CMAKE_FIND_LIBRARY_SUFFIXES .a .dll.a)
+elseif(APPLE)
+  # macOS CI builds libshout as a Universal static archive (.a) with openssl
+  # linked in; prefer the static over a .dylib so find_library picks the
+  # archive when both happen to be present.
+  list(PREPEND CMAKE_FIND_LIBRARY_SUFFIXES .a)
 endif()
 
 find_library(


### PR DESCRIPTION
**Summary**

Phase 2 §E.1 — rebuild macOS CI's libshout with openssl linked in, so `shout_set_tls(SHOUT_TLS_AUTO_NO_PLAIN)` will actually return a usable handle at runtime instead of `SHOUTERR_UNSUPPORTED`. Infrastructure only — no user-visible TLS feature in this PR. Progresses #32; the TLS source plumbing + UI checkbox land in the follow-up (§E.2 + §E.3 combined).

Blocking issue the old config had: `.github/scripts/build-macos` was passing `--without-openssl` to libshout's configure, so the shipped macOS plugin had no TLS support at all. Ubuntu (`libshout3-dev` from apt) and Windows (streaming already optional) are unaffected — the fix is macOS-only.

What changed:

- `.github/scripts/build-macos`
  - New **openssl@3.3.2** Universal build step (2-pass arm64 + x86_64 via `darwin64-{arm,x86_64}-cc` with `no-shared no-tests`, then `lipo` of `libssl.a` + `libcrypto.a` into `/tmp/openssl-universal`). Headers copied from the arm64 slice — `opensslconf.h` branches on arch macros at compile time so one header tree works for both slices.
  - **libshout** configure switched to static (`--disable-shared --enable-static`) and now points at the per-arch openssl prefix (`--with-openssl=/tmp/openssl-{arm64,x86_64}`). `--without-openssl` dropped. `lipo` merges into `libshout.a` instead of `libshout.dylib`.
  - New **TLS-symbol sanity check**: `nm /tmp/libshout-universal/lib/libshout.a | grep _SSL_connect` — CI fails fast with a clear error if TLS silently didn't compile in, rather than discovering it at §E.2 acceptance-test time.
  - `-DOPENSSL_ROOT_DIR=/tmp/openssl-universal` added to the cmake args.
- `CMakeLists.txt`
  - New `if(APPLE)` block: `find_package(OpenSSL REQUIRED)` with `OPENSSL_USE_STATIC_LIBS ON`, links `OpenSSL::SSL` + `OpenSSL::Crypto`. libshout.a references SSL_*/EVP_* call sites but doesn't embed the definitions — the plugin bundle has to provide them.
- `cmake/FindLibShout.cmake`
  - `.a` prepended to `CMAKE_FIND_LIBRARY_SUFFIXES` on Apple (matches the existing FindLibLame pattern), so `find_library` picks the new static archive over any stray `.dylib`.

Design calls:

- **Static libshout + static openssl** (not a libshout dylib that embeds openssl at dylib-link time) — keeps the final `.plugin` bundle free of runtime dylib deps, matching how liblame and libopus already ship. Cost is the extra `find_package(OpenSSL)` + link step in the plugin; benefit is a self-contained bundle (verify via `otool -L`).
- **Apple-only CMake block.** Ubuntu's `libshout3-dev` is already built with TLS upstream; Windows streaming is still optional pending MSVC libshout (OQ #2). No cross-platform spaghetti.
- **openssl 3.3.2 pin.** Intentional version pin in CI — bumps are deliberate, not on every run.

**Test plan**

Regression: existing behavior must not change. Streaming feature itself is not touched in this PR — the `ssl` + `crypto` symbols are now linked but nothing calls them yet (that's §E.2).

1. **Regression — MP3 streaming still works (PR #58 Test 1 replay).**
   - Start Icecast 2 locally: `docker run --rm -d --name icecast -p 8000:8000 moul/icecast`
   - OBS → Tools → Radio Output… → host `localhost`, port `8000`, user `source`, password `hackme`, mount `/stream`, codec MP3, protocol Icecast. Start.
   - In the plugin log: `[obs-radio-output] Connected to server` appears. State transitions: `DISCONNECTED → CONNECTING → CONNECTED`.
   - VLC: open `http://localhost:8000/stream` — audio plays.
   - Stop. Log shows `Disconnected` once (not twice). No 57 s hang.
   - ✅ **PASS** — 2026-04-22 22:02, CI artifact from run 24816991506 installed to `~/Library/Application Support/obs-studio/plugins/`. Log:
     ```
     22:02:23.680: [obs-radio-output] MP3 encoder: 48000 Hz, 2 ch, 128 kbps
     22:02:24.117: [obs-radio-output] Connected to localhost:8000/stream
     22:02:24.118: [obs-radio-output] Encoder send thread started (codec=mp3)
     22:02:54.831: [obs-radio-output] Encoder send thread stopped
     22:02:54.832: [obs-radio-output] Disconnected from localhost:8000/stream
     ```
     Clean connect → send → disconnect, single `Disconnected` line, no hang.
2. **Regression — Opus streaming still works (PR #58 Test 2 replay).**
   - Same Icecast server. In OBS settings set the sample rate to 48 000 Hz (Opus prereq).
   - OBS → Tools → Radio Output… → switch codec to Opus. Start.
   - Icecast admin (`http://localhost:8000/admin/stats.xsl`, user `admin`, password `hackme`): mount `/stream` shows `server_type: audio/ogg`, `subtype: Opus`.
   - VLC plays the stream; title bar shows Opus.
   - Stop. Restart. Stream re-plays cleanly (reconnect header re-emit path still works).
   - ✅ **PASS** — 2026-04-22 22:03, same CI artifact. Opus encoder init + clean stop/restart cycle + an unplanned mid-test reconnect all green. Log:
     ```
     22:03:44.931: [obs-radio-output] Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312
     22:03:45.543: [obs-radio-output] Connected to localhost:8000/stream
     22:03:45.543: [obs-radio-output] Encoder send thread started (codec=opus)
     22:04:23.013: [obs-radio-output] Encoder send thread stopped
     22:04:23.014: [obs-radio-output] Disconnected from localhost:8000/stream
     22:04:24.571: [obs-radio-output] Opus encoder: 48000 Hz, 2 ch, 96 kbps, pre-skip 312
     22:04:25.024: [obs-radio-output] Connected to localhost:8000/stream
     22:04:25.024: [obs-radio-output] Encoder send thread started (codec=opus)
     22:04:44.486: [obs-radio-output] [send-thread] shout_send() failed: Socket error
     22:04:44.486: [obs-radio-output] [reconnect] reconnect thread started (delay 3000 ms, max 5 retries)
     22:04:47.594: [obs-radio-output] [reconnect] attempt 1/5 to localhost:8000/stream ...
     22:04:48.017: [obs-radio-output] [opus] re-emitted Ogg container headers after reconnect (107 bytes, serial 0xbe099fe1)
     22:04:48.018: [obs-radio-output] [reconnect] reconnected to localhost:8000/stream
     ```
     Opus init clean, first-session stop-restart clean, AND an unplanned mid-test socket error triggered the reconnect path — which recovered on attempt 1/5 with a fresh-serial OpusHead+OpusTags page re-emit (107 bytes, serial `0xbe099fe1`). PR #58's `on_reconnect` vtable hook is intact under the new static-everything link model.
3. **Infra — libshout.a TLS symbols present post-rebuild.**
   - After CI's macOS job: `nm /tmp/libshout-universal/lib/libshout.a | grep _SSL_connect` returns a non-empty match. The script already fails the job if this grep is empty, so a green CI run is itself the proof.
   - Local replay (optional): run `.github/scripts/build-macos` with `CI=1` in a scratch shell and watch for the `libshout.a TLS symbols present (_SSL_connect found)` log line.
   - ✅ **PASS** — CI run [24816991506](https://github.com/Tech-Noid-Systems/obs-radio-output/actions/runs/24816991506) macOS job logged `libshout.a TLS symbols present (_SSL_connect found)`. The job's build-macos script fails with exit 2 if the grep is empty, so a green run is the authoritative signal.
4. **Infra — .plugin bundle has no dylib runtime deps on libssl/libcrypto/libshout.**
   - After CI's macOS artifact lands (or locally): `otool -L release/RelWithDebInfo/obs-radio-output.plugin/Contents/MacOS/obs-radio-output`
   - Expected output contains: `OBS::libobs`, `Qt6::Widgets`, `Qt6::Core`, system frameworks (`Cocoa`, `CoreFoundation`, `libc++.1.dylib`, `libSystem.B.dylib`). Notably NOT expected: `libshout.*.dylib`, `libssl.*.dylib`, `libcrypto.*.dylib`, `libmp3lame.*.dylib`, `libopus.*.dylib`, `libogg.*.dylib`.
   - ✅ **PASS** — 2026-04-22 22:04, `otool -L` on both architectures of the installed `.plugin` binary. Link list per arch (x86_64 and arm64 identical):
     ```
     /System/Library/Frameworks/IOKit.framework/…
     /System/Library/Frameworks/DiskArbitration.framework/…
     /System/Library/Frameworks/UniformTypeIdentifiers.framework/…
     /System/Library/Frameworks/AppKit.framework/…
     /System/Library/Frameworks/OpenGL.framework/…
     /System/Library/Frameworks/ImageIO.framework/…
     /System/Library/Frameworks/Metal.framework/…
     /System/Library/Frameworks/AGL.framework/…
     @rpath/libobs.framework/Versions/A/libobs
     @rpath/obs-frontend-api.dylib
     @rpath/QtCore.framework/Versions/A/QtCore
     @rpath/QtGui.framework/Versions/A/QtGui
     @rpath/QtWidgets.framework/Versions/A/QtWidgets
     /usr/lib/libc++.1.dylib
     /usr/lib/libSystem.B.dylib
     ```
     Zero occurrences of `libshout*`, `libssl*`, `libcrypto*`, `libmp3lame*`, `libopus*`, `libogg*`. The static-everything link model took — the bundle is fully self-contained.

---

### ✅ All tests PASS — ready to merge

CI passes (clang-format, CMake format, CodeQL, macOS build, Ubuntu x86_64 + aarch64, Windows) — the macOS build job's internal `nm` check is the new infra-level gate.

Follow-up: §E.2 (`shout_set_tls(SHOUT_TLS_AUTO_NO_PLAIN)` + error handling for `SHOUTERR_NOTLS` / `SHOUTERR_TLSBADCERT`) and §E.3 (TLS checkbox in the config dialog) land as a single PR after this one merges.
