### PR TITLE
ci(release): accept alpha pre-release tags alongside beta and rc

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,7 +47,7 @@ jobs:
               echo 'prerelease=false' >> $GITHUB_OUTPUT
               echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
               ;;
-            +([0-9]).+([0-9]).+([0-9])-@(beta|rc)*([0-9]) )
+            +([0-9]).+([0-9]).+([0-9])-@(alpha|beta|rc)*([0-9]) )
               echo 'validTag=true' >> $GITHUB_OUTPUT
               echo 'prerelease=true' >> $GITHUB_OUTPUT
               echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Summary**
- The tag-validation regex in \`push.yaml\`'s \`create-release\` job currently accepts only \`X.Y.Z\`, \`X.Y.Z-betaN\`, and \`X.Y.Z-rcN\`. An \`X.Y.Z-alphaN\` tag gets built (the outer \`tags: '*'\` trigger fires \`build-project\`) but falls through to \`validTag=false\` — no GitHub Release, no artifact upload, no checksums.
- This one-char addition (\`@(beta|rc)\` → \`@(alpha|beta|rc)\`) lets us cut alpha pre-releases without renaming the phase to \`beta1\` or hand-creating a Release. \`alpha\` is standard SemVer pre-release terminology and matches what users expect from a pre-feature-complete project (Phase 2 / Phase 3 scope is still open).
- Surfaced while prepping to cut \`0.1.0-alpha1\` per #62 — exactly the kind of pipeline bug #62 was set up to shake out at low stakes.

Fixes part of #62.

**Test plan**
- CI passes (yaml lint, build, no format churn)
- Next alpha tag (\`0.1.0-alpha1\`) will be the real end-to-end test — if the Release draft appears with artifacts attached, the regex change works.