### PR TITLE
ci(release): auto-populate release body + alpha regex + buildspec version from tag

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -42,7 +42,7 @@ jobs:
               ;;
             push)
               config_data=('codesign:true' 'notarize:false' 'package:true' 'config:RelWithDebInfo')
-              if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta).+)? ]]; then
+              if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta|alpha).+)? ]]; then
                 config_data[1]='notarize:true'
                 config_data[3]='config:Release'
               fi

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -84,6 +84,17 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Override version from tag 🏷️
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          : Override version from tag 🏷️
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          mv buildspec.json.new buildspec.json
+          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
+
       - name: Set Up Environment 🔧
         id: setup
         run: |
@@ -191,6 +202,17 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Override version from tag 🏷️
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          : Override version from tag 🏷️
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          mv buildspec.json.new buildspec.json
+          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
+
       - name: Set Up Environment 🔧
         id: setup
         run: |
@@ -263,6 +285,17 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Override version from tag 🏷️
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          : Override version from tag 🏷️
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          mv buildspec.json.new buildspec.json
+          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
 
       - name: Set Up Environment 🔧
         id: setup

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,6 +34,11 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Checkout Repository 📥
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Check Release Tag ☑️
         id: check
         run: |
@@ -100,6 +105,27 @@ jobs:
             echo "    ${file##*/}: $(sha256sum "${file}" | cut -d " " -f 1)" >> ${{ github.workspace }}/CHECKSUMS.txt
           done
 
+      - name: Generate Release Notes 📝
+        if: fromJSON(steps.check.outputs.validTag)
+        id: cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Assemble Release Body 🧩
+        if: fromJSON(steps.check.outputs.validTag)
+        run: |
+          : Assemble Release Body 🧩
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+
+          {
+            printf '%s\n\n' "${{ steps.cliff.outputs.content }}"
+            cat "${{ github.workspace }}/CHECKSUMS.txt"
+          } > "${{ github.workspace }}/RELEASE_BODY.md"
+
       - name: Create Release 🛫
         if: fromJSON(steps.check.outputs.validTag)
         id: create_release
@@ -109,7 +135,7 @@ jobs:
           prerelease: ${{ fromJSON(steps.check.outputs.prerelease) }}
           tag_name: ${{ steps.check.outputs.version }}
           name: ${{ needs.build-project.outputs.pluginName }} ${{ steps.check.outputs.version }}
-          body_path: ${{ github.workspace }}/CHECKSUMS.txt
+          body_path: ${{ github.workspace }}/RELEASE_BODY.md
           files: |
             ${{ github.workspace }}/*.exe
             ${{ github.workspace }}/*.zip


### PR DESCRIPTION
**Summary**

Three small CI changes, all `ci(release):`, that make tagged releases fully hands-off — no manual release-body editing, no pre-tag `buildspec.json` bump, and alpha pre-releases are first-class (closes the regex gap symmetric to PR #65).

Context: cutting \`0.1.0-alpha1\` (PR #65 era) surfaced three gaps:
1. `build-project.yaml`'s notarize/config regex accepts `rc|beta` but not `alpha` → alpha1 was built unnotarized + as RelWithDebInfo. Gatekeeper would flag the `.pkg`.
2. \`push.yaml\`'s \`create-release\` job writes only \`CHECKSUMS.txt\` to the release body. The \`git-cliff\` output that release.yaml commits to \`CHANGELOG.md\` isn't wired into the Release.
3. \`buildspec.json\` \`version\` is a hardcoded \`0.1.0\`, so alpha1's artifacts are named \`obs-radio-output-0.1.0-*\` — the tag suffix never reaches the filename. Any future alpha2 would produce indistinguishable file names.

Each commit addresses one of the above.

**Commits**

1. `ci(release): accept alpha pre-release tags in build-project notarize/config guard`
   One-char regex fix in \`build-project.yaml\` line 45. \`@(rc|beta)\` → \`@(rc|beta|alpha)\`. Completes the pattern PR #65 applied to \`push.yaml\`. After this, alpha tags get notarized + Release config, same as beta/rc.

2. `ci(release): populate release body with git-cliff-generated notes + checksums`
   Adds three steps to \`push.yaml\`'s \`create-release\` job:
   - Full-history checkout (git-cliff needs tag history).
   - \`orhun/git-cliff-action@v4\` with \`--latest --strip header\` → generates just the current release's section (not the full changelog) per \`cliff.toml\`'s Conventional-Commits template.
   - Assembles \`RELEASE_BODY.md\` = \`[cliff output]\\n\\n[CHECKSUMS.txt]\`.
   \`body_path\` flipped from \`CHECKSUMS.txt\` to \`RELEASE_BODY.md\`. Result: every tag produces a release with a narrative body (grouped feat:/fix:/ci:/docs: with PR links) plus the checksums block.

3. `ci(release): patch buildspec.json version from tag name at build time`
   New "Override version from tag" step inserted in all three build jobs (macOS / Ubuntu / Windows), right after checkout and before Set Up Environment. \`if: github.ref_type == 'tag'\` gated. \`jq\`-patches \`buildspec.json\`'s \`version\` field with \`\${GITHUB_REF_NAME}\` in-place. \`jq\` is preinstalled on all three runner images. \`shell: bash\` explicit so the step is identical across runners (Windows has Git Bash). Source of truth for release version becomes the tag itself; no pre-tag buildspec bumps.

**Downstream effects**

- Future tags produce fully hands-off releases — tag, wait for CI, publish.
- \`0.1.0-alpha1\` draft will be deleted and re-cut against this main after merge (Aaron decision). That gives us the first "real" hands-off release as our validation run.
- \`buildspec.json\` on main stays at \`0.1.0\` — deliberate, so non-tag builds produce un-suffixed artifacts. Only tagged builds get the suffix.

**Test plan**
- [x] CI passes (yaml lint, build, no format churn)
- [ ] After merge: \`gh release delete 0.1.0-alpha1 --cleanup-tag --yes\`, re-push tag \`0.1.0-alpha1\` on the merge commit. Verify:
  - \`build-project\` macOS job uses \`config:Release\` and \`notarize:true\` (check Actions log for the Check Event Data step)
  - \`.pkg\` filename is \`obs-radio-output-0.1.0-alpha1-macos-universal.pkg\` (carries the \`-alpha1\` suffix)
  - Draft release body contains git-cliff narrative + checksums (not just checksums)
- [ ] Verify un-tagged main pushes still build cleanly (the new step is gated, should be a no-op on non-tag runs)

Partially related: #62 (release pipeline validation — this PR makes the pipeline meaningfully more complete).