### PR TITLE
ci(release): strip SemVer suffix for CMake + restore it in artifact filenames

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -91,9 +91,15 @@ jobs:
           : Override version from tag 🏷️
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          # CMake's project(VERSION) rejects SemVer pre-release suffixes
+          # ("0.1.0-alpha1" → format-invalid), so strip everything after
+          # the first hyphen before writing to buildspec.json.  The full
+          # tag (including suffix) is reintroduced as a filename-level
+          # rename in push.yaml's create-release job.
+          numeric_version="${GITHUB_REF_NAME%%-*}"
+          jq --arg v "$numeric_version" '.version = $v' buildspec.json > buildspec.json.new
           mv buildspec.json.new buildspec.json
-          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
+          echo "Patched buildspec.json version -> $numeric_version (full tag: ${GITHUB_REF_NAME})"
 
       - name: Set Up Environment 🔧
         id: setup
@@ -209,9 +215,15 @@ jobs:
           : Override version from tag 🏷️
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          # CMake's project(VERSION) rejects SemVer pre-release suffixes
+          # ("0.1.0-alpha1" → format-invalid), so strip everything after
+          # the first hyphen before writing to buildspec.json.  The full
+          # tag (including suffix) is reintroduced as a filename-level
+          # rename in push.yaml's create-release job.
+          numeric_version="${GITHUB_REF_NAME%%-*}"
+          jq --arg v "$numeric_version" '.version = $v' buildspec.json > buildspec.json.new
           mv buildspec.json.new buildspec.json
-          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
+          echo "Patched buildspec.json version -> $numeric_version (full tag: ${GITHUB_REF_NAME})"
 
       - name: Set Up Environment 🔧
         id: setup
@@ -293,9 +305,15 @@ jobs:
           : Override version from tag 🏷️
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          jq --arg v "${GITHUB_REF_NAME}" '.version = $v' buildspec.json > buildspec.json.new
+          # CMake's project(VERSION) rejects SemVer pre-release suffixes
+          # ("0.1.0-alpha1" → format-invalid), so strip everything after
+          # the first hyphen before writing to buildspec.json.  The full
+          # tag (including suffix) is reintroduced as a filename-level
+          # rename in push.yaml's create-release job.
+          numeric_version="${GITHUB_REF_NAME%%-*}"
+          jq --arg v "$numeric_version" '.version = $v' buildspec.json > buildspec.json.new
           mv buildspec.json.new buildspec.json
-          echo "Patched buildspec.json version -> ${GITHUB_REF_NAME}"
+          echo "Patched buildspec.json version -> $numeric_version (full tag: ${GITHUB_REF_NAME})"
 
       - name: Set Up Environment 🔧
         id: setup

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -93,6 +93,36 @@ jobs:
             done
           done
 
+      - name: Inject Pre-release Suffix into Asset Names 🏷️
+        if: fromJSON(steps.check.outputs.validTag) && contains(steps.check.outputs.version, '-')
+        run: |
+          : Inject Pre-release Suffix into Asset Names 🏷️
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+          shopt -s extglob nullglob
+
+          # CMake's project(VERSION) only accepts numeric major.minor.patch,
+          # so build-project.yaml patches buildspec.json with the numeric
+          # portion of the tag only.  CPack then produces files like
+          # "obs-radio-output-0.1.0-macos-universal.pkg".  For pre-release
+          # tags ("0.1.0-alpha1") we rewrite the filenames here so the
+          # assets carry the full tag name and can't be confused with the
+          # final release's artifacts once we hit 0.1.0.
+          tag="${GITHUB_REF_NAME}"
+          numeric="${tag%%-*}"
+
+          cd "${{ github.workspace }}"
+          for f in @(*.exe|*.zip|*.pkg|*.deb|*.ddeb|*.tar.xz); do
+            [[ -f "$f" ]] || continue
+            new="${f//-${numeric}-/-${tag}-}"
+            if [[ "$new" == "$f" ]]; then
+              new="${f/-${numeric}./-${tag}.}"
+            fi
+            if [[ "$new" != "$f" ]]; then
+              mv "$f" "$new"
+              echo "Renamed: $f -> $new"
+            fi
+          done
+
       - name: Generate Checksums 🪪
         if: fromJSON(steps.check.outputs.validTag)
         run: |


### PR DESCRIPTION
**Summary**

Fixes the CMake-rejects-suffix crash surfaced by the re-cut `0.1.0-alpha1` tag — PR #68's buildspec patch wrote the full tag (`0.1.0-alpha1`) into `buildspec.json`'s `version` field, which flowed into `CMakeLists.txt:5`'s `project(VERSION \${_version})` call. CMake's `project(VERSION)` only accepts numeric `major.minor.patch`; SemVer pre-release suffixes are a hard error:

\`\`\`
CMake Error at CMakeLists.txt:5 (project):
  VERSION "0.1.0-alpha1" format invalid.
\`\`\`

All three build jobs failed on the tag push, `create-release` was skipped, no draft release got produced.

**Fix**

Two edits — same intent, split between the two workflows where each logical concern lives.

1. **\`build-project.yaml\` — strip SemVer suffix before patching \`buildspec.json\`.**
   \`numeric_version=\${GITHUB_REF_NAME%%-*}\` — everything up to the first hyphen. Tag \`0.1.0-alpha1\` → patches buildspec with \`0.1.0\`. Tag \`0.2.0\` → patches buildspec with \`0.2.0\` (useful even when no suffix: keeps numeric-bump hands-off for future minor releases). CMake sees a clean numeric version every time.

2. **\`push.yaml\` — restore the suffix at artifact-filename level.**
   New \`Inject Pre-release Suffix into Asset Names 🏷️\` step, gated on \`contains(steps.check.outputs.version, '-')\` so it's a no-op for final releases. After CPack has produced \`obs-radio-output-0.1.0-macos-universal.pkg\`, this step substitutes \`-\${numeric}-\` → \`-\${tag}-\` in the filename, handling both mid-name occurrences (\`-0.1.0-macos-universal.pkg\` → \`-0.1.0-alpha1-macos-universal.pkg\`) and trailing-version occurrences (\`-0.1.0.tar.xz\` → \`-0.1.0-alpha1.tar.xz\`). Runs before \`Generate Checksums\` so the checksum block shows the final filenames. \`shell: bash\` is the default for the job.

**Downstream**

- Tag \`0.1.0-alpha1\` on the merged main will:
  - Patch buildspec → \`0.1.0\`
  - CMake builds \`obs-radio-output-0.1.0-*\` artifacts (numeric version only)
  - Rename step rewrites to \`obs-radio-output-0.1.0-alpha1-*\`
  - Checksum block, release body, and attached assets all carry the suffix
  - Final \`.pkg\` name on the release: \`obs-radio-output-0.1.0-alpha1-macos-universal.pkg\`
- The broken \`0.1.0-alpha1\` tag on main will be deleted + re-cut after this merges.

**Test plan**
- [x] CI passes on this non-tag PR run (the new step is gated, no-op on non-tag pushes; \`Override version from tag\` is gated, no-op on non-tag pushes).
- [ ] After merge + re-tag: verify macOS `.pkg` filename in the release is \`obs-radio-output-0.1.0-alpha1-macos-universal.pkg\` (with the suffix), and all three build jobs complete — confirming the CMake-version fix.