### PR TITLE
fix(dock): preserve Error state so users see connection-failure feedback

### DIFF
--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -202,8 +202,25 @@ extern "C" obs_data_t *frontend_wire_get_config(void)
 extern "C" bool frontend_wire_start_output(void)
 {
 	if (g_active_output_handle) {
-		obs_log(LOG_INFO, "[frontend-wire] output already running; start request ignored");
-		return true;
+		/* An errored start leaves the handle retained so the dock can
+		 * keep showing Error until the user acknowledges.  A fresh
+		 * start request implicitly acknowledges — release the stale
+		 * errored handle and fall through to create a new one. */
+		struct radio_output *existing = radio_output_get_active();
+		bool errored = false;
+		if (existing) {
+			pthread_mutex_lock(&existing->state_mutex);
+			errored = (existing->state == RADIO_STATE_ERROR);
+			pthread_mutex_unlock(&existing->state_mutex);
+		}
+		if (errored) {
+			obs_log(LOG_INFO, "[frontend-wire] releasing prior errored output before retrying start");
+			obs_output_release(g_active_output_handle);
+			g_active_output_handle = nullptr;
+		} else {
+			obs_log(LOG_INFO, "[frontend-wire] output already running; start request ignored");
+			return true;
+		}
 	}
 	if (!g_config) {
 		obs_log(LOG_ERROR, "[frontend-wire] cannot start output: config not loaded");
@@ -217,9 +234,14 @@ extern "C" bool frontend_wire_start_output(void)
 	}
 
 	if (!obs_output_start(g_active_output_handle)) {
-		obs_log(LOG_ERROR, "[frontend-wire] obs_output_start failed");
-		obs_output_release(g_active_output_handle);
-		g_active_output_handle = nullptr;
+		obs_log(LOG_ERROR, "[frontend-wire] obs_output_start failed; "
+				   "context retained in Error state for dock acknowledgement");
+		/* DO NOT release the handle here.  The context's state is
+		 * RADIO_STATE_ERROR; releasing would destroy the context
+		 * immediately and the dock would poll g_active_output == NULL,
+		 * overwriting Error with Disconnected in the UI.  The user
+		 * clears the error by clicking Stop, which calls
+		 * frontend_wire_stop_output() and releases the handle there. */
 		return false;
 	}
 

--- a/src/radio-output-dock.cpp
+++ b/src/radio-output-dock.cpp
@@ -175,7 +175,11 @@ void RadioOutputDock::pollState()
 
 	const bool running = (state == RADIO_STATE_CONNECTING || state == RADIO_STATE_CONNECTED ||
 			      state == RADIO_STATE_RECONNECTING);
-	start_->setEnabled(!running);
+	/* Error is sticky until the user clicks Stop — disable Start so the
+	 * only action available is acknowledging the failure.  Otherwise a
+	 * second Start click would silently no-op against the retained
+	 * errored handle (see frontend_wire_start_output). */
+	start_->setEnabled(!running && state != RADIO_STATE_ERROR);
 	stop_->setEnabled(running || state == RADIO_STATE_ERROR);
 
 	const bool connected = (state == RADIO_STATE_CONNECTED);

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -89,7 +89,8 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 static void radio_output_teardown(struct radio_output *context)
 {
 	pthread_mutex_lock(&context->state_mutex);
-	if (context->state == RADIO_STATE_DISCONNECTED) {
+	radio_state_t entry_state = context->state;
+	if (entry_state == RADIO_STATE_DISCONNECTED) {
 		pthread_mutex_unlock(&context->state_mutex);
 		return;
 	}
@@ -137,7 +138,12 @@ static void radio_output_teardown(struct radio_output *context)
 	}
 #endif /* HAVE_LIBSHOUT */
 
-	set_state(context, RADIO_STATE_DISCONNECTED);
+	/* Preserve RADIO_STATE_ERROR so the dock keeps showing red until the
+	 * user acknowledges by clicking Stop, which releases the obs_output_t
+	 * handle and calls destroy — at which point the context is freed and
+	 * the dock polls g_active_output == NULL, rendering Disconnected. */
+	if (entry_state != RADIO_STATE_ERROR)
+		set_state(context, RADIO_STATE_DISCONNECTED);
 	obs_log(LOG_INFO, "Disconnected from %s:%d%s", context->host, context->port, context->mount);
 }
 

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -314,8 +314,12 @@ static void *encoder_send_thread(void *data)
 			if (context->reconnect_enabled) {
 				reconnect_start(context);
 			} else {
+				/* OBS_OUTPUT_ERROR (not _DISCONNECTED) so OBS's own
+				 * framework reconnect doesn't kick in and re-call
+				 * radio_output_start behind our back; the user's
+				 * auto-reconnect-disabled choice means stop here. */
 				set_state(context, RADIO_STATE_ERROR);
-				obs_output_signal_stop(context->output, OBS_OUTPUT_DISCONNECTED);
+				obs_output_signal_stop(context->output, OBS_OUTPUT_ERROR);
 			}
 			continue;
 		}


### PR DESCRIPTION
## Summary

Error state is currently set correctly in the code but the dock almost never displays it — teardown and the frontend-wire start path both race ahead and flip the state to Disconnected before the dock's 500 ms poll picks it up. This PR makes Error sticky until the user clicks Stop, matching the existing UI contract (`stop_->setEnabled(running || state == RADIO_STATE_ERROR)` at `radio-output-dock.cpp:217` already implied Error was supposed to be sticky).

## The bug

Three races, one symptom:

1. **Start-fail race** — `radio_output_start` sets `RADIO_STATE_ERROR` and returns false. `frontend_wire_start_output` immediately releases the handle (`frontend-wire.cpp:221`), triggering destroy → teardown → context freed. Dock polls, `radio_output_get_active()` returns NULL, local `state` defaults to Disconnected, label goes grey.
2. **Mid-stream / reconnect-give-up race** — error paths call `obs_output_signal_stop`, which invokes our stop callback → `radio_output_teardown`. Teardown unconditionally calls `set_state(RADIO_STATE_DISCONNECTED)` at `radio-output.c:140`, overwriting the Error that was just set.
3. **OBS-framework-reconnect hijack** (surfaced by §4 testing) — when our auto-reconnect is disabled and the send thread hits a socket error, we used to signal `OBS_OUTPUT_DISCONNECTED`, which OBS's own framework reconnect treats as "transient, retry me." OBS would then re-call `radio_output_start` on a 2/3/4/6/9 s exponential backoff, masking the Error and producing duplicate teardown logs on user Stop.

Net effect: red indicator flashes for microseconds (if at all), and users get zero feedback on why their broadcast failed.

## The fix

Four coordinated changes:

1. **`radio-output.c` — teardown preserves Error.** Snapshot the entry state; skip the final `set_state(DISCONNECTED)` when entry state was Error. The context stays in Error until the handle is released via destroy.
2. **`frontend-wire.cpp` — don't release on start failure.** Leave the handle retained so the context survives with `state == ERROR` for the dock to poll. `frontend_wire_stop_output` releases it when the user clicks Stop. Also added logic to clear a stale errored handle if `frontend_wire_start_output` is called again (e.g. from the OBS-streaming-tied path with the checkbox enabled), so the retry path isn't blocked.
3. **`radio-output-dock.cpp` — disable Start during Error.** The user's only action out of Error is now Stop (acknowledge + clear). Prevents the silent-no-op from a double-click.
4. **`radio-output.c:318` — signal `OBS_OUTPUT_ERROR` on send-fail when auto-reconnect is disabled.** Was `OBS_OUTPUT_DISCONNECTED`, which OBS framework picked up as a retry signal and triggered its own stock reconnect loop. Switching to ERROR matches the reconnect-give-up path in `reconnect.c:128/168` and keeps the dock in red sticky Error.

## Test plan

### Setup

- Build installs automatically via `zsh build-and-install-macos.sh` and `cp` to `~/Library/Application Support/obs-studio/plugins/` — already done, so just relaunch OBS.
- Keep **Help → Log Files → View Current Log** open in a second window to verify the log lines below.

### 1. Start-fail shows red Error (PRIMARY BUG) ✅ PASS

- [x] Open **Tools → Radio Output…**, enter a **wrong password**, OK.
- [x] Click **Start** on the dock.
- [x] Status label shows red **"Error"** (not grey Disconnected).
- [x] Start button becomes **disabled**; Stop button stays **enabled**.
- [x] Log contains: `[frontend-wire] obs_output_start failed; context retained in Error state for dock acknowledgement`
- [x] Click **Stop**.
- [x] Status label goes grey **"Disconnected"**. Start becomes enabled.

Evidence — first run hit `Couldn't connect` (server not yet up), second run hit `Login failed` (bad creds against running Icecast). Both branches retained the handle, dock went red, Stop click cleanly tore it down with `Disconnected from localhost:8000/stream` (single log line).

### 2. Good creds → Live (no regression on happy path) ✅ PASS

- [x] Fix the password back to correct, OK.
- [x] Click **Start** → status goes (Connecting → optional, may be transient) → green **"Live"**.
- [x] Log contains: `Connected to <host>:<port><mount>` and `Encoder send thread started`.
- [x] Click **Stop** → grey Disconnected.
- [x] Log contains: `Encoder send thread stopped` and `Disconnected from <host>:<port><mount>`.

Evidence — full sequence at 21:06:22.021 → 21:06:24.625: `MP3 encoder: 48000 Hz, 2 ch, 128 kbps` → `Connected to localhost:8000/stream` → `Encoder send thread started (codec=mp3)` → `Encoder send thread stopped` → `Disconnected from localhost:8000/stream`. Single Disconnected line.

### 3. Mid-stream failure with reconnect enabled → orange → red ✅ PASS

- [x] Enable reconnect in config (default is on). ~~Set max retries low (e.g. **2**) so the test finishes quickly.~~ Tested with default 5 retries.
- [x] Start a clean broadcast → Live (green).
- [x] Kill the Icecast server (stop the docker container or `pkill icecast2`).
- [x] Within 500 ms, status goes **orange Reconnecting**.
- [x] After 5 failed retries, status goes **red Error**.
- [x] Start **disabled**, Stop **enabled**.
- [x] Log contains: `[reconnect] max retries (5) exceeded — giving up`.
- [x] Click **Stop** → grey Disconnected.

Evidence — 5 reconnect attempts on 3s spacing all logged `shout_open() failed: Couldn't connect`, then `[reconnect] max retries (5) exceeded — giving up` at 21:08:27.417. Dock confirmed red after give-up. Stop click → single `Disconnected from localhost:8000/stream` line at 21:09:11.703.

### 4. Mid-stream failure with reconnect DISABLED → red immediately ✅ PASS

First run uncovered that `radio-output.c:318` was signalling `OBS_OUTPUT_DISCONNECTED` instead of `OBS_OUTPUT_ERROR`, which let OBS's own framework reconnect kick in (visible as `Output 'radio_output_inst': Reconnecting in 2.00 seconds..` lines) and produced a duplicate `Disconnected from ...` log on Stop. Fix landed as commit `8d90232` (`fix(reconnect): signal OBS_OUTPUT_ERROR when auto-reconnect disabled`) on this branch — re-tested clean.

- [x] Open config, uncheck Auto-reconnect, OK.
- [x] Start → Live.
- [x] Kill Icecast.
- [x] Within 500 ms, status goes **red Error** (no orange Reconnecting phase).
- [x] Log contains: `[send-thread] shout_send() failed: Socket error` followed immediately by **no** `Output 'radio_output_inst': Reconnecting in N seconds..` lines and **no** repeated `MP3 encoder: 48000 Hz, 2 ch, 128 kbps` re-init lines.
- [x] Click **Stop** → grey Disconnected.
- [x] Log contains exactly **one** `Disconnected from <host>:<port><mount>` line (was duplicated in the broken case).

Evidence (post-fix run): `21:36:58 [send-thread] shout_send() failed: Socket error` → no framework-reconnect lines → user clicks Stop → `21:37:55 Encoder send thread stopped` + single `21:37:55 Disconnected from localhost:8000/stream`.

### 5. OBS-streaming-tied retry clears the stale Error ✅ PASS

- [x] Enable Auto-reconnect again AND the "Start/stop radio with OBS streaming" checkbox.
- [x] With **wrong password** set, click OBS's main **Start Streaming**.
- [x] Dock goes red Error. Log contains the retained-handle line from test 1.
- [x] Click OBS's **Stop Streaming**.
- [x] Fix password, click **Start Streaming** again.
- [x] Dock goes green Live.

Evidence (sequence at 21:47:59 → 21:48:19):
- 21:47:59 — `OBS streaming starting — auto-starting radio output` → `shout_open() failed: Login failed` → `obs_output_start failed; context retained in Error state for dock acknowledgement` → `radio auto-start failed; OBS video streaming continues unaffected`. RTMP stream proceeds normally — confirms our failure didn't block OBS video.
- 21:48:02 — `OBS streaming stopping — auto-stopping radio output` → single `Disconnected from localhost:8000/stream`.
- 21:48:16 — second auto-start with corrected creds → `Connected to localhost:8000/stream` → `Encoder send thread started`.
- 21:48:19 — auto-stop on second OBS Stop Streaming → clean teardown.

Variance from spec: the `[frontend-wire] releasing prior errored output before retrying start` log line did not fire because the Stop Streaming between attempts already auto-released the errored handle via `frontend_wire_stop_output`. That defensive code path only fires if a user starts again *without* stopping first. Test plan was over-specified; the user-visible behavior is correct.

### 6. Sanity ✅ PASS

- [x] `git diff origin/main...HEAD --stat` touches exactly 3 files: `radio-output.c`, `frontend-wire.cpp`, `radio-output-dock.cpp`.
- [x] pre-commit passed (clang-format ran — diff reflects format-clean output).
- [x] CI green across macOS + Ubuntu + Windows.

### Pass criteria

Sections 1-5 all ticked, CI green. Section 1 is the primary regression; the others guard against the fix breaking existing flows. **All 6 sections ✅ PASS — ready for merge.**

## Follow-up filed

[#80](https://github.com/Tech-Noid-Systems/obs-radio-output/issues/80) — Move teardown `shout_close` to detached cleanup thread to prevent blocking on dead peer. Pre-existing hardening gap surfaced anecdotally during §4 testing as "close was a bit slower than normal"; not introduced by this PR. Phase 3.
