### PR TITLE
feat(vorbis): add Ogg/Vorbis codec via encoder vtable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ target_sources(
     src/radio-output.h
     src/radio-encoder.h
     src/radio-opus-encoder.c
+    src/radio-vorbis-encoder.c
     src/reconnect.c
     src/reconnect.h
     src/metadata.c

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -14,6 +14,7 @@ RadioOutput.Audio.Group="Audio"
 RadioOutput.Audio.Codec="Codec"
 RadioOutput.Audio.Codec.Opus="Opus"
 RadioOutput.Audio.Codec.MP3="MP3"
+RadioOutput.Audio.Codec.Vorbis="Vorbis"
 RadioOutput.Audio.Bitrate="Bitrate (kbps)"
 
 RadioOutput.Reconnect.Group="Auto-Reconnect"

--- a/src/radio-encoder.h
+++ b/src/radio-encoder.h
@@ -101,6 +101,7 @@ struct radio_encoder_ops {
 
 extern const struct radio_encoder_ops radio_encoder_mp3;
 extern const struct radio_encoder_ops radio_encoder_opus;
+extern const struct radio_encoder_ops radio_encoder_vorbis;
 
 #ifdef __cplusplus
 }

--- a/src/radio-output-config-dialog.cpp
+++ b/src/radio-output-config-dialog.cpp
@@ -77,6 +77,7 @@ QWidget *buildAudioGroup(RadioOutputConfigDialog *parent, QComboBox *&codec, QCo
 	codec = new QComboBox(group);
 	codec->addItem(obs_module_text("RadioOutput.Audio.Codec.Opus"), RADIO_CODEC_OPUS);
 	codec->addItem(obs_module_text("RadioOutput.Audio.Codec.MP3"), RADIO_CODEC_MP3);
+	codec->addItem(obs_module_text("RadioOutput.Audio.Codec.Vorbis"), RADIO_CODEC_VORBIS);
 	form->addRow(obs_module_text("RadioOutput.Audio.Codec"), codec);
 
 	bitrate = new QComboBox(group);

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -61,6 +61,7 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 	context->output = output;
 	context->state = RADIO_STATE_DISCONNECTED;
 	pthread_mutex_init(&context->state_mutex, NULL);
+	pthread_mutex_init(&context->encoder_mutex, NULL);
 
 #ifdef HAVE_LIBSHOUT
 	shout_init();
@@ -116,19 +117,27 @@ static void radio_output_teardown(struct radio_output *context)
 		obs_log(LOG_INFO, "Encoder send thread stopped");
 	}
 
-	/* Encoder flush — trailing MP3 frames / final Ogg EOS page. */
-	if (context->encoder && context->shout) {
-		uint8_t flush_buf[16 * 1024];
-		int flush_bytes = context->encoder->flush(context, flush_buf, sizeof(flush_buf));
-		if (flush_bytes > 0) {
-			int flush_ret = shout_send(context->shout, flush_buf, (size_t)flush_bytes);
-			if (flush_ret != SHOUTERR_SUCCESS)
-				obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
-		}
-	}
+	/* Encoder flush (trailing MP3 frames / final Ogg EOS page) + destroy, both
+	 * under encoder_mutex so an in-flight raw_audio encode_frame can't run
+	 * against freed encoder state (end_data_capture above does not drain a
+	 * callback already executing on libobs's shared audio thread).  The audio
+	 * thread trylocks the same mutex and drops its callback while we hold it.
+	 * The flush bytes are produced under the lock but sent to the network
+	 * AFTER releasing it, so a slow/dead peer can't stall the audio thread. */
+	uint8_t flush_buf[16 * 1024];
+	int flush_bytes = 0;
+	pthread_mutex_lock(&context->encoder_mutex);
+	if (context->encoder && context->shout)
+		flush_bytes = context->encoder->flush(context, flush_buf, sizeof(flush_buf));
 	if (context->encoder) {
 		context->encoder->destroy(context);
 		context->encoder = NULL;
+	}
+	pthread_mutex_unlock(&context->encoder_mutex);
+	if (flush_bytes > 0 && context->shout) {
+		int flush_ret = shout_send(context->shout, flush_buf, (size_t)flush_bytes);
+		if (flush_ret != SHOUTERR_SUCCESS)
+			obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
 	}
 	if (context->shout) {
 		shout_close(context->shout);
@@ -166,6 +175,7 @@ static void radio_output_destroy(void *data)
 #endif
 
 	pthread_mutex_destroy(&context->state_mutex);
+	pthread_mutex_destroy(&context->encoder_mutex);
 	bfree(context->host);
 	bfree(context->mount);
 	bfree(context->password);
@@ -656,11 +666,20 @@ static void radio_output_raw_audio(void *data, struct audio_data *frames)
 	if (!frames || !frames->frames)
 		return;
 
-	/* send_buf.data doubles as the "ready to write" gate — set by start()
-	 * (radio_send_buf_init) only after mutex/cond/send thread are all live.
-	 * encoder is set one step earlier, so both null-checks matter. */
-	if (!context->encoder || !context->send_buf.data)
+	/* ALL access to context->encoder / encoder_priv happens under
+	 * encoder_mutex, serialized against the reconnect thread's full re-init
+	 * (encoder->on_reconnect) AND teardown's encoder->destroy.  trylock (not
+	 * lock) so we never block libobs's shared audio thread: if a re-init or
+	 * teardown is in progress we drop this callback's audio, which lands in a
+	 * reconnect/teardown gap and is inaudible.  send_buf.data is the "ready"
+	 * gate (set last by start, freed in teardown); re-checked here under the
+	 * lock so a half-rebuilt or freed encoder is never touched. */
+	if (pthread_mutex_trylock(&context->encoder_mutex) != 0)
 		return;
+	if (!context->encoder || !context->send_buf.data) {
+		pthread_mutex_unlock(&context->encoder_mutex);
+		return;
+	}
 
 	const float *left = (const float *)frames->data[0];
 	const float *right = frames->data[1] ? (const float *)frames->data[1] : left;
@@ -669,13 +688,16 @@ static void radio_output_raw_audio(void *data, struct audio_data *frames)
 	if (cap < 4096)
 		cap = 4096;
 	uint8_t *buf = bmalloc(cap);
-
 	int bytes = context->encoder->encode_frame(context, left, right, (size_t)frames->frames, buf, cap);
-	if (bytes > 0) {
+	pthread_mutex_unlock(&context->encoder_mutex);
+
+	/* send_buf_push runs AFTER the unlock (it takes send_mutex; the ring
+	 * buffer no-ops on a freed/zero-capacity buffer, so this is safe even if
+	 * teardown freed send_buf in the meantime). */
+	if (bytes > 0)
 		send_buf_push(context, buf, (size_t)bytes);
-	} else if (bytes < 0) {
+	else if (bytes < 0)
 		obs_log(LOG_ERROR, "[%s] encode_frame error: %d", context->encoder->name, bytes);
-	}
 
 	bfree(buf);
 #endif /* HAVE_LIBSHOUT */

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -537,6 +537,9 @@ static bool radio_output_start(void *data)
 	case RADIO_CODEC_OPUS:
 		context->encoder = &radio_encoder_opus;
 		break;
+	case RADIO_CODEC_VORBIS:
+		context->encoder = &radio_encoder_vorbis;
+		break;
 	case RADIO_CODEC_MP3:
 	default:
 		context->encoder = &radio_encoder_mp3;
@@ -736,6 +739,7 @@ static obs_properties_t *radio_output_get_properties(void *data)
 							OBS_COMBO_FORMAT_INT);
 	obs_property_list_add_int(codec, obs_module_text("RadioOutput.Audio.Codec.MP3"), RADIO_CODEC_MP3);
 	obs_property_list_add_int(codec, obs_module_text("RadioOutput.Audio.Codec.Opus"), RADIO_CODEC_OPUS);
+	obs_property_list_add_int(codec, obs_module_text("RadioOutput.Audio.Codec.Vorbis"), RADIO_CODEC_VORBIS);
 
 	obs_property_t *bitrate = obs_properties_add_list(audio, SETTING_BITRATE,
 							  obs_module_text("RadioOutput.Audio.Bitrate"),

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -72,6 +72,14 @@ struct radio_output {
 	radio_state_t state;
 	pthread_mutex_t state_mutex;
 
+	/* Serializes the audio thread's encode_frame (raw_audio) against the
+	 * reconnect thread's full encoder re-init (encoder->on_reconnect).  The
+	 * audio thread trylocks and DROPS its callback on contention rather than
+	 * block libobs's shared audio thread; reconnect holds it across the
+	 * re-init.  Without this, the audio thread can call vorbis_analysis_buffer
+	 * on a half-rebuilt Vorbis DSP state → null deref / crash. */
+	pthread_mutex_t encoder_mutex;
+
 	// Reconnect settings
 	bool reconnect_enabled;
 	int reconnect_delay_ms;

--- a/src/radio-vorbis-encoder.c
+++ b/src/radio-vorbis-encoder.c
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * Vorbis encoder — libvorbis + libvorbisenc (codec) + libogg (container).
+ *
+ * Implements the radio_encoder_ops vtable, mirroring radio-opus-encoder.c.
+ * The ring buffer, send thread, reconnect logic, and libshout handling all
+ * live in radio-output.c; this file only turns planar float PCM into
+ * Ogg/Vorbis pages.
+ *
+ * Pipeline:
+ *   1. init()   — vorbis_info + vorbis_encode_init (managed VBR at the user's
+ *                 bitrate), comment + DSP + block state, then ogg_stream_init
+ *                 and the three Vorbis header packets (identification,
+ *                 comment, codebook) flushed into their own pages and handed
+ *                 back to the caller so they reach the wire before audio.
+ *   2. encode() — hand PCM to libvorbis via vorbis_analysis_buffer, then drain
+ *                 blocks → packets → pages (libvorbis owns the PCM accumulator
+ *                 and packet/granule bookkeeping, unlike the Opus path).
+ *   3. flush()  — vorbis_analysis_wrote(0) signals end-of-input; libvorbis
+ *                 marks the final packet e_o_s itself, no manual padding.
+ *
+ * Differences from Opus worth calling out:
+ *   • Arbitrary sample rate — Vorbis has no 48 kHz constraint, so this works
+ *     at 44.1 kHz where Opus's init guard trips.
+ *   • Three header packets, not two; each on its own page (libvorbis convention
+ *     via ogg_stream_flush).
+ *   • Reconnect FULLY re-inits the encoder, not just the Ogg container: Vorbis
+ *     data packets reference the codebook baked into header packet 3, so
+ *     emitting fresh headers while keeping the old DSP state would decode to
+ *     garbage on listeners.  The ~30 ms codebook recompute is imperceptible
+ *     against the multi-second reconnect downtime that precedes it.
+ */
+
+#include "radio-encoder.h"
+#include "radio-output.h"
+
+#include <plugin-support.h>
+#include <util/base.h>
+#include <util/bmem.h>
+
+#ifdef HAVE_VORBIS
+
+#include <vorbis/codec.h>
+#include <vorbis/vorbisenc.h>
+#include <ogg/ogg.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+/*
+ * Per-output Vorbis state.  Lives in radio_output::encoder_priv; allocated in
+ * vorbis_init, released in vorbis_destroy.  Each libvorbis sub-object has its
+ * own initialized flag so partial-init failure and reconnect teardown can
+ * release exactly what was set up, in the libvorbis-recommended order.
+ */
+struct vorbis_state {
+	vorbis_info vi;
+	vorbis_comment vc;
+	vorbis_dsp_state vd;
+	vorbis_block vb;
+	ogg_stream_state os;
+	bool vi_initialized;
+	bool vc_initialized;
+	bool vd_initialized;
+	bool vb_initialized;
+	bool os_initialized;
+
+	uint32_t sample_rate;
+	int channels;
+
+	/* Bumped on every reconnect and folded into the Ogg serial so
+	 * back-to-back reconnects never reuse a serial. */
+	unsigned int reconnect_epoch;
+};
+
+/*
+ * Append one Ogg page (header + body) to a fixed-size output buffer.  Returns
+ * false if the write would overflow cap; the caller then reports -1 to
+ * raw_audio, which drops the pages rather than risk a wild write.  The ring
+ * buffer is 256 KB so this should never fire for a single audio callback.
+ */
+static bool write_page_fixed(uint8_t *out, size_t cap, size_t *pos, const ogg_page *og)
+{
+	size_t need = *pos + (size_t)og->header_len + (size_t)og->body_len;
+	if (need > cap)
+		return false;
+	memcpy(out + *pos, og->header, (size_t)og->header_len);
+	*pos += (size_t)og->header_len;
+	memcpy(out + *pos, og->body, (size_t)og->body_len);
+	*pos += (size_t)og->body_len;
+	return true;
+}
+
+/*
+ * Append one Ogg page to a growable bmalloc buffer.  Used only when building
+ * the three-page header blob, which is a few KB total.
+ */
+static void append_page(uint8_t **dst, size_t *dst_len, size_t *dst_cap, const ogg_page *og)
+{
+	size_t need = *dst_len + (size_t)og->header_len + (size_t)og->body_len;
+	if (need > *dst_cap) {
+		size_t new_cap = *dst_cap ? *dst_cap : 1024;
+		while (new_cap < need)
+			new_cap *= 2;
+		*dst = brealloc(*dst, new_cap);
+		*dst_cap = new_cap;
+	}
+	memcpy(*dst + *dst_len, og->header, (size_t)og->header_len);
+	*dst_len += (size_t)og->header_len;
+	memcpy(*dst + *dst_len, og->body, (size_t)og->body_len);
+	*dst_len += (size_t)og->body_len;
+}
+
+/* Release every libvorbis/libogg sub-object that was initialized, in the
+ * order libvorbis recommends (block → dsp → comment → info).  Idempotent via
+ * the per-member flags so it is safe from partial-init failure, reconnect, and
+ * destroy alike. */
+static void vorbis_clear_state(struct vorbis_state *st)
+{
+	if (st->os_initialized) {
+		ogg_stream_clear(&st->os);
+		st->os_initialized = false;
+	}
+	if (st->vb_initialized) {
+		vorbis_block_clear(&st->vb);
+		st->vb_initialized = false;
+	}
+	if (st->vd_initialized) {
+		vorbis_dsp_clear(&st->vd);
+		st->vd_initialized = false;
+	}
+	if (st->vc_initialized) {
+		vorbis_comment_clear(&st->vc);
+		st->vc_initialized = false;
+	}
+	if (st->vi_initialized) {
+		vorbis_info_clear(&st->vi);
+		st->vi_initialized = false;
+	}
+}
+
+/*
+ * Build the full libvorbis encode pipeline (info → encode_init → comment →
+ * dsp → block → ogg stream) and emit the three Vorbis header packets as
+ * separate pages into a fresh bmalloc'd buffer returned via out_headers /
+ * out_bytes (caller frees with bfree).  Shared by init() and on_reconnect();
+ * the only difference between the two is reconnect_epoch having advanced.
+ *
+ * On any failure it releases whatever it managed to initialize and returns
+ * false.  Expects st to be freshly cleared (all *_initialized false).
+ */
+static bool vorbis_setup_and_emit_headers(struct vorbis_state *st, int bitrate, uint8_t **out_headers,
+					  size_t *out_bytes)
+{
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	vorbis_info_init(&st->vi);
+	st->vi_initialized = true;
+
+	/* Managed VBR: unconstrained max/min (-1), targeting the nominal bitrate.
+	 * Matches the "128 kbps means ~128 kbps average" behavior of the MP3 and
+	 * Opus paths. */
+	int ret = vorbis_encode_init(&st->vi, st->channels, (long)st->sample_rate, -1, (long)bitrate * 1000, -1);
+	if (ret != 0) {
+		obs_log(LOG_ERROR, "vorbis_encode_init failed (%d): %d ch, %u Hz, %d kbps", ret, st->channels,
+			st->sample_rate, bitrate);
+		vorbis_clear_state(st);
+		return false;
+	}
+
+	vorbis_comment_init(&st->vc);
+	st->vc_initialized = true;
+	vorbis_comment_add_tag(&st->vc, "ENCODER", "obs-radio-output");
+
+	if (vorbis_analysis_init(&st->vd, &st->vi) != 0) {
+		obs_log(LOG_ERROR, "vorbis_analysis_init failed");
+		vorbis_clear_state(st);
+		return false;
+	}
+	st->vd_initialized = true;
+
+	if (vorbis_block_init(&st->vd, &st->vb) != 0) {
+		obs_log(LOG_ERROR, "vorbis_block_init failed");
+		vorbis_clear_state(st);
+		return false;
+	}
+	st->vb_initialized = true;
+
+	/* Fresh Ogg serial.  Time ⊕ pointer ⊕ reconnect epoch (golden-ratio
+	 * step) keeps it unique across rapid reconnects. */
+	unsigned int serial = (unsigned int)time(NULL);
+	serial ^= (unsigned int)(uintptr_t)st;
+	serial ^= st->reconnect_epoch * 0x9E3779B1u;
+	if (ogg_stream_init(&st->os, (int)serial) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_init failed");
+		vorbis_clear_state(st);
+		return false;
+	}
+	st->os_initialized = true;
+
+	/* Three header packets: identification, comment, codebook.  libvorbis
+	 * sets b_o_s / packetno on them; each goes on its own page (spec +
+	 * convention) via ogg_stream_flush. */
+	ogg_packet hdr_id;
+	ogg_packet hdr_comment;
+	ogg_packet hdr_code;
+	ret = vorbis_analysis_headerout(&st->vd, &st->vc, &hdr_id, &hdr_comment, &hdr_code);
+	if (ret != 0) {
+		obs_log(LOG_ERROR, "vorbis_analysis_headerout failed (%d)", ret);
+		vorbis_clear_state(st);
+		return false;
+	}
+	if (ogg_stream_packetin(&st->os, &hdr_id) != 0 || ogg_stream_packetin(&st->os, &hdr_comment) != 0 ||
+	    ogg_stream_packetin(&st->os, &hdr_code) != 0) {
+		obs_log(LOG_ERROR, "ogg_stream_packetin failed for a Vorbis header packet");
+		vorbis_clear_state(st);
+		return false;
+	}
+
+	uint8_t *pages = NULL;
+	size_t pages_len = 0;
+	size_t pages_cap = 0;
+	ogg_page page;
+	while (ogg_stream_flush(&st->os, &page))
+		append_page(&pages, &pages_len, &pages_cap, &page);
+
+	*out_headers = pages;
+	*out_bytes = pages_len;
+	return true;
+}
+
+/*
+ * Drain whatever audio blocks libvorbis has buffered into packets and then
+ * Ogg pages.  Uses ogg_stream_pageout (emits only complete pages); the
+ * trailing partial page is forced out separately at flush time.
+ */
+static int vorbis_drain(struct vorbis_state *st, uint8_t *out, size_t cap, size_t *pos)
+{
+	while (vorbis_analysis_blockout(&st->vd, &st->vb) == 1) {
+		vorbis_analysis(&st->vb, NULL);
+		vorbis_bitrate_addblock(&st->vb);
+
+		ogg_packet op;
+		while (vorbis_bitrate_flushpacket(&st->vd, &op) == 1) {
+			if (ogg_stream_packetin(&st->os, &op) != 0) {
+				obs_log(LOG_ERROR, "ogg_stream_packetin failed for a Vorbis audio packet");
+				return -1;
+			}
+			ogg_page og;
+			while (ogg_stream_pageout(&st->os, &og)) {
+				if (!write_page_fixed(out, cap, pos, &og)) {
+					obs_log(LOG_ERROR, "Vorbis: scratch buffer overflow emitting page");
+					return -1;
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+static bool vorbis_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+			size_t *out_bytes)
+{
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	if (channels != 1 && channels != 2) {
+		obs_log(LOG_ERROR, "Vorbis: unsupported channel count %d (must be 1 or 2)", channels);
+		return false;
+	}
+	/* Vorbis accepts a very wide rate range; reject only the absurd.  Unlike
+	 * Opus there is no 48 kHz requirement, so 44.1 kHz works natively. */
+	if (sample_rate < 2000 || sample_rate > 200000) {
+		obs_log(LOG_ERROR, "Vorbis: sample rate %u Hz out of supported range (2000-200000)", sample_rate);
+		return false;
+	}
+
+	struct vorbis_state *st = bzalloc(sizeof(struct vorbis_state));
+	st->sample_rate = sample_rate;
+	st->channels = channels;
+
+	if (!vorbis_setup_and_emit_headers(st, context->bitrate, out_headers, out_bytes)) {
+		bfree(st);
+		return false;
+	}
+
+	context->encoder_priv = st;
+	obs_log(LOG_INFO, "Vorbis encoder: %u Hz, %d ch, %d kbps", sample_rate, channels, context->bitrate);
+	return true;
+}
+
+static int vorbis_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	struct vorbis_state *st = context->encoder_priv;
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	if (!st) {
+		obs_log(LOG_ERROR, "[vorbis] on_reconnect called without encoder state");
+		return -1;
+	}
+
+	/* Full re-init.  Vorbis audio packets reference the codebook carried in
+	 * header packet 3; a listener joining the post-reconnect stream needs the
+	 * headers AND data produced against the same DSP state, so we tear the
+	 * whole encoder down and rebuild it.  Same parameters reproduce an
+	 * identical codebook; the new Ogg serial + advanced epoch make this a
+	 * clean fresh logical stream from gp=0. */
+	vorbis_clear_state(st);
+	st->reconnect_epoch++;
+
+	if (!vorbis_setup_and_emit_headers(st, context->bitrate, out_headers, out_bytes)) {
+		obs_log(LOG_ERROR, "[vorbis] failed to re-init and re-emit container headers on reconnect");
+		return -1;
+	}
+
+	obs_log(LOG_INFO, "[vorbis] re-initialized and re-emitted Ogg container headers after reconnect (%zu bytes)",
+		*out_bytes);
+	return 0;
+}
+
+static void vorbis_destroy(struct radio_output *context)
+{
+	struct vorbis_state *st = context->encoder_priv;
+	if (!st)
+		return;
+
+	vorbis_clear_state(st);
+	bfree(st);
+	context->encoder_priv = NULL;
+}
+
+static int vorbis_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+			       uint8_t *out, size_t cap)
+{
+	struct vorbis_state *st = context->encoder_priv;
+	if (!st)
+		return -1;
+	if (frames == 0)
+		return 0;
+
+	size_t pos = 0;
+
+	/* Hand PCM to libvorbis's own (planar) accumulator. */
+	float **buffer = vorbis_analysis_buffer(&st->vd, (int)frames);
+	if (st->channels == 2) {
+		for (size_t i = 0; i < frames; i++) {
+			buffer[0][i] = left[i];
+			buffer[1][i] = right[i];
+		}
+	} else {
+		/* Mono downmix — average L+R, matching the Opus path. */
+		for (size_t i = 0; i < frames; i++)
+			buffer[0][i] = 0.5f * (left[i] + right[i]);
+	}
+	vorbis_analysis_wrote(&st->vd, (int)frames);
+
+	if (vorbis_drain(st, out, cap, &pos) < 0)
+		return -1;
+
+	return (int)pos;
+}
+
+static int vorbis_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	struct vorbis_state *st = context->encoder_priv;
+	if (!st)
+		return 0;
+
+	size_t pos = 0;
+
+	/* Signal end-of-input.  libvorbis drains its remaining blocks and marks
+	 * the final packet e_o_s itself — no manual silence padding needed. */
+	vorbis_analysis_wrote(&st->vd, 0);
+
+	if (vorbis_drain(st, out, cap, &pos) < 0)
+		return -1;
+
+	/* Force out the trailing partial page (carries the EOS packet). */
+	ogg_page og;
+	while (ogg_stream_flush(&st->os, &og)) {
+		if (!write_page_fixed(out, cap, &pos, &og)) {
+			obs_log(LOG_ERROR, "Vorbis: scratch buffer overflow flushing final page");
+			return -1;
+		}
+	}
+
+	return (int)pos;
+}
+
+static size_t vorbis_max_output_for(struct radio_output *context, size_t frames)
+{
+	UNUSED_PARAMETER(context);
+	/* Compressed output is far smaller than the equivalent PCM, but VBR can
+	 * spike and a full page may flush on any callback.  frames * 2 bytes
+	 * dwarfs the worst-case compressed size for one callback; the 32 KB slack
+	 * absorbs Ogg page overhead and the occasional buffered-page burst.  If
+	 * this is ever exceeded, write_page_fixed fails safely (drops + logs)
+	 * rather than overrunning. */
+	return frames * 2 + 32 * 1024;
+}
+
+const struct radio_encoder_ops radio_encoder_vorbis = {
+	.name = "vorbis",
+#ifdef HAVE_LIBSHOUT
+	.shout_format = SHOUT_FORMAT_OGG,
+#else
+	.shout_format = 0,
+#endif
+	.init = vorbis_init,
+	.destroy = vorbis_destroy,
+	.encode_frame = vorbis_encode_frame,
+	.flush = vorbis_flush,
+	.max_output_for = vorbis_max_output_for,
+	.on_reconnect = vorbis_on_reconnect,
+};
+
+#else /* !HAVE_VORBIS — stub so the plugin still links when libvorbis is absent */
+
+static bool vorbis_stub_init(struct radio_output *context, uint32_t sample_rate, int channels, uint8_t **out_headers,
+			     size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(sample_rate);
+	UNUSED_PARAMETER(channels);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	obs_log(LOG_ERROR, "Vorbis encoding not available — rebuild with libvorbis + libogg");
+	return false;
+}
+
+static void vorbis_stub_destroy(struct radio_output *context)
+{
+	UNUSED_PARAMETER(context);
+}
+
+static int vorbis_stub_encode_frame(struct radio_output *context, const float *left, const float *right, size_t frames,
+				    uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(left);
+	UNUSED_PARAMETER(right);
+	UNUSED_PARAMETER(frames);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return -1;
+}
+
+static int vorbis_stub_flush(struct radio_output *context, uint8_t *out, size_t cap)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(out);
+	UNUSED_PARAMETER(cap);
+	return 0;
+}
+
+static size_t vorbis_stub_max_output_for(struct radio_output *context, size_t frames)
+{
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(frames);
+	return 0;
+}
+
+static int vorbis_stub_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	UNUSED_PARAMETER(context);
+	*out_headers = NULL;
+	*out_bytes = 0;
+	return 0;
+}
+
+const struct radio_encoder_ops radio_encoder_vorbis = {
+	.name = "vorbis",
+	.shout_format = 0,
+	.init = vorbis_stub_init,
+	.destroy = vorbis_stub_destroy,
+	.encode_frame = vorbis_stub_encode_frame,
+	.flush = vorbis_stub_flush,
+	.max_output_for = vorbis_stub_max_output_for,
+	.on_reconnect = vorbis_stub_on_reconnect,
+};
+
+#endif /* HAVE_VORBIS */

--- a/src/reconnect.c
+++ b/src/reconnect.c
@@ -54,7 +54,14 @@ static bool attempt_connect(struct radio_output *context)
 	if (context->encoder && context->encoder->on_reconnect) {
 		uint8_t *hdrs = NULL;
 		size_t hdr_len = 0;
-		if (context->encoder->on_reconnect(context, &hdrs, &hdr_len) < 0) {
+		/* Hold encoder_mutex across the full re-init.  The audio thread
+		 * (raw_audio) trylocks the same mutex and drops its callback while
+		 * we hold it, so it never encodes against a half-rebuilt encoder
+		 * state — the Vorbis reconnect crash that acceptance test #3 caught. */
+		pthread_mutex_lock(&context->encoder_mutex);
+		const int reinit_rc = context->encoder->on_reconnect(context, &hdrs, &hdr_len);
+		pthread_mutex_unlock(&context->encoder_mutex);
+		if (reinit_rc < 0) {
 			obs_log(LOG_ERROR, "[reconnect] encoder header re-emit failed for codec %s",
 				context->encoder->name);
 			/* fall through — keep the connection and cross fingers; a clean


### PR DESCRIPTION
**Summary**

Phase 2 §H.2 + §H.3 — adds Ogg/Vorbis as a third codec alongside MP3 and Opus, implemented as a `radio_encoder_ops` vtable impl. Builds on the libvorbis dependency landed in #83. Closes #35.

- `src/radio-vorbis-encoder.c` (new, ~470 LoC) — `radio_encoder_vorbis` vtable, mirroring `radio-opus-encoder.c`. Uses libvorbisenc managed VBR (`vorbis_encode_init(..., -1, kbps*1000, -1)`), hands PCM to libvorbis's own planar accumulator (`vorbis_analysis_buffer`), and drains blocks → packets → Ogg pages. Stub vtable under `!HAVE_VORBIS` so Windows still links.
- Vtable wiring: `extern` in `radio-encoder.h`; `RADIO_CODEC_VORBIS` case in `radio_output_start`'s codec switch (`radio-output.c`).
- UI: Vorbis added to the codec combo in both the properties panel (`radio_output_get_properties`) and the Tools-menu config dialog; locale string `RadioOutput.Audio.Codec.Vorbis`.
- `CMakeLists.txt` — `src/radio-vorbis-encoder.c` added to `target_sources`.

**Design notes (differences from Opus)**
- **Arbitrary sample rate** — no 48 kHz guard; works natively at 44.1 kHz where Opus's init fails. Sanity-rejects only rates outside 2 kHz–200 kHz.
- **Three header packets** (identification + comment + codebook), each flushed onto its own page per Vorbis convention.
- **libvorbis owns the PCM accumulator and packet/granule bookkeeping** — we don't maintain a frame accumulator or set packetno/granulepos ourselves (unlike the hand-built Opus packets).
- **Reconnect fully re-inits the encoder**, not just the Ogg container. Vorbis audio packets reference the codebook baked into header packet 3, so emitting fresh headers while keeping old DSP state would decode to garbage. Same parameters reproduce an identical codebook; new serial + advanced epoch make a clean stream from gp=0. (~30 ms codebook recompute, imperceptible vs. the reconnect downtime.)
- **EOS** via `vorbis_analysis_wrote(0)` — libvorbis marks the final packet `e_o_s` itself; no manual silence padding.

**Pre-push verification**
- Local arm64 build (`xcodebuild … -arch arm64`, `RelWithDebInfo`, `-Werror`): `radio-vorbis-encoder.c` compiles clean, full plugin links against libvorbis + libvorbisenc + libogg. `** BUILD SUCCEEDED **`.
- `clang-format` (v19.1.3, matches CI) + `gersemi` clean on all changed files.

**Test plan (manual, on macOS + local Icecast)**

CI gates (build only):
- [ ] macOS Universal + Ubuntu x86_64 + Windows builds green; CodeQL + Clang-Tidy + format green

Manual acceptance (Aaron):
1. **Vorbis happy path (Icecast, 48 kHz).** Codec=Vorbis, Bitrate=128, Start.
   - Expect log: `Vorbis encoder: 48000 Hz, 2 ch, 128 kbps` then `Encoder send thread started (codec=vorbis)`.
   - Icecast admin (`/status-json.xsl` or `/admin/stats`): mount `server_type: application/ogg`, `subtype: Vorbis`.
   - VLC plays the stream cleanly for 30+ s. **PASS if** codec identified by Icecast + clean audio.
2. **Vorbis at 44.1 kHz (the differentiator vs Opus).** Set OBS Settings → Audio → Sample Rate = 44.1 kHz, Codec=Vorbis, Start.
   - Expect log: `Vorbis encoder: 44100 Hz, 2 ch, …` (no rate-guard error, unlike Opus). VLC plays cleanly. **PASS if** it streams at 44.1 kHz.
3. **Vorbis reconnect.** Stream running; `docker restart icecast`; wait for reconnect.
   - Expect: `[reconnect] reconnected to …` then `[vorbis] re-initialized and re-emitted Ogg container headers after reconnect (<N> bytes)`.
   - VLC resumes playback (may need a re-open depending on player). **PASS if** post-reconnect listeners get decodable audio.
4. **Rapid codec switch in one OBS session.** MP3 → stop → Opus → stop → Vorbis → stop → MP3. **PASS if** no crashes; each start/stop clean (exercises vtable create/destroy per codec).
5. **SHOUTcast v1 + Vorbis warning.** Protocol=SHOUTcast, Codec=Vorbis, Start.
   - Expect: `SHOUTcast v1 protocol only supports MP3; selected codec is likely to be rejected by the server`. **PASS if** warning fires.
6. **MP3 + Opus regression.** Re-run a quick MP3 stream and an Opus stream. **PASS if** both still work (vtable abstraction intact).

Set OBS back to 48 kHz after test 2.