### PR TITLE
test(metadata): cover song truncation at METADATA_SONG_MAX

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,11 @@ function(radio_add_test name)
     # ever run on the build/CI machine and never ship, so pin them to the host
     # architecture.
     set_target_properties(${name} PROPERTIES OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+    # libobs is consumed as a framework on macOS and its headers use
+    # double-quoted includes; suppress the framework-header diagnostics that the
+    # plugin target also suppresses, so a test that pulls obs headers builds
+    # under -Werror.
+    target_compile_options(${name} PRIVATE -Wno-quoted-include-in-framework-header -Wno-comma)
   endif()
   # PRE_TEST discovery defers test enumeration to `ctest` run time instead of
   # running the binary as a post-build step — more robust under the Xcode
@@ -33,3 +38,21 @@ function(radio_add_test name)
 endfunction()
 
 radio_add_test(test_smoke test_smoke.cpp)
+
+# Metadata song-truncation test (#74).  Compiles src/metadata.c directly into
+# the test target and stubs its externals (obs_log, the libshout metadata API,
+# radio_output_get_active) in test_metadata.cpp.  metadata.c includes
+# radio-output.h (→ obs-module.h) and, under HAVE_LIBSHOUT, shout.h, so the
+# target needs both include trees — pulled headers-only from the imported
+# targets (no link; the called functions are stubbed).
+radio_add_test(test_metadata test_metadata.cpp ${CMAKE_SOURCE_DIR}/src/metadata.c)
+target_compile_definitions(test_metadata PRIVATE HAVE_LIBSHOUT)
+target_include_directories(
+  test_metadata
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    $<TARGET_PROPERTY:OBS::libobs,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:LibShout::LibShout,INTERFACE_INCLUDE_DIRECTORIES>
+)
+find_package(Threads REQUIRED)
+target_link_libraries(test_metadata PRIVATE Threads::Threads)

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for the "Now Playing" song truncation in src/metadata.c (issue
+// #74).  metadata.c is compiled directly into this test target; its external
+// dependencies (obs_log, the libshout metadata API, radio_output_get_active)
+// are satisfied by the minimal stubs below.  The stubbed shout_metadata_add
+// captures the song value so we can assert exactly what metadata_update()
+// would have put on the wire — which is where the METADATA_SONG_MAX (255 byte)
+// snprintf cap applies.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <pthread.h>
+#include <string>
+
+extern "C" {
+#include "metadata.h"
+#include "radio-output.h"
+}
+
+// ---- Captured state + stubs for metadata.c's externals ----
+
+static char g_captured_song[4096];
+static bool g_captured;
+
+extern "C" {
+void obs_log(int log_level, const char *format, ...)
+{
+	(void)log_level;
+	(void)format;
+}
+
+shout_metadata_t *shout_metadata_new(void)
+{
+	return reinterpret_cast<shout_metadata_t *>(1);
+}
+
+int shout_metadata_add(shout_metadata_t *self, const char *name, const char *value)
+{
+	(void)self;
+	(void)name;
+	std::strncpy(g_captured_song, value, sizeof(g_captured_song) - 1);
+	g_captured_song[sizeof(g_captured_song) - 1] = '\0';
+	g_captured = true;
+	return SHOUTERR_SUCCESS;
+}
+
+void shout_metadata_free(shout_metadata_t *self)
+{
+	(void)self;
+}
+
+int shout_set_metadata_utf8(shout_t *self, shout_metadata_t *metadata)
+{
+	(void)self;
+	(void)metadata;
+	return SHOUTERR_SUCCESS;
+}
+
+const char *shout_get_error(shout_t *self)
+{
+	(void)self;
+	return "stub";
+}
+
+// metadata.c also defines radio_output_update_metadata(), which references
+// this; never called from the tests but must resolve at link time.
+struct radio_output *radio_output_get_active(void)
+{
+	return nullptr;
+}
+}
+
+namespace {
+// Drive metadata_update() with a connected context and return the song string
+// that reached shout_metadata_add (i.e. post-truncation).
+std::string run_update(const std::string &title)
+{
+	g_captured = false;
+	g_captured_song[0] = '\0';
+
+	struct radio_output ctx;
+	std::memset(&ctx, 0, sizeof(ctx));
+	pthread_mutex_init(&ctx.state_mutex, nullptr);
+	ctx.state = RADIO_STATE_CONNECTED;
+	ctx.shout = reinterpret_cast<shout_t *>(1);
+
+	int rc = metadata_update(&ctx, title.c_str());
+	pthread_mutex_destroy(&ctx.state_mutex);
+
+	REQUIRE(rc == 0);
+	REQUIRE(g_captured);
+	return std::string(g_captured_song);
+}
+} // namespace
+
+TEST_CASE("metadata song shorter than the cap passes through unchanged", "[metadata]")
+{
+	const std::string title(100, 'a');
+	REQUIRE(run_update(title) == title);
+}
+
+TEST_CASE("metadata song exactly at the 255-byte cap passes through unchanged", "[metadata]")
+{
+	const std::string title(255, 'b');
+	const std::string got = run_update(title);
+	REQUIRE(got.size() == 255);
+	REQUIRE(got == title);
+}
+
+TEST_CASE("metadata song longer than the cap is truncated to 255 bytes", "[metadata]")
+{
+	const std::string title(512, 'c');
+	const std::string got = run_update(title);
+	REQUIRE(got.size() == 255);
+	REQUIRE(got == std::string(255, 'c'));
+}


### PR DESCRIPTION
**Summary**

Second step of the Tier 1 automated-testing MVP (issue #74) — the first *real* test, validating the `extern "C"` + compile-the-`.c`-into-the-test pattern that #75/#76 reuse. Blocked-by #73 (now merged).

- `tests/test_metadata.cpp` — compiles `src/metadata.c` directly into the test target and stubs its externals (`obs_log`, the libshout metadata API, `radio_output_get_active`). The stubbed `shout_metadata_add` captures the song value, so the test asserts exactly what `metadata_update()` would put on the wire — which is where the `METADATA_SONG_MAX` (255-byte) `snprintf` cap applies.
  - Case (a): title < 255 bytes passes through unchanged.
  - Case (b): exactly 255 bytes passes through unchanged.
  - Case (c): 512 bytes truncates to exactly 255.
- `tests/CMakeLists.txt` — registers `test_metadata` via the `radio_add_test` helper, adds `HAVE_LIBSHOUT`, pulls the obs + libshout include trees **headers-only** from the imported targets (no link — the called functions are stubbed), and links `Threads::Threads`. The `radio_add_test` helper also now suppresses `-Wquoted-include-in-framework-header` / `-Wcomma` on Apple, since libobs is consumed as a framework there and its headers use quoted includes (the plugin target already suppresses these).

No production-code changes — only test-target additions; the production build is unchanged.

**Test plan — ✅ verified locally (macOS arm64), CI to confirm**
- [x] Local `ctest`: `4/4 tests passed` (smoke + 3 metadata cases) — built via `cmake --build … --target radio-tests` under `-Werror`
- [ ] macOS CI build + `ctest` green (libobs framework headers, Catch2 from Homebrew)
- [ ] Ubuntu x86_64 CI build + `ctest` green (Catch2 from apt, libobs not a framework)
- [ ] Windows build green — unaffected (`ENABLE_TESTING` not set on the Windows preset)
- [ ] clang-format (`tests/*.cpp`) + gersemi (`tests/CMakeLists.txt`) + Conventional Commits green
- [ ] Production build unchanged

Note: caught locally before push — the test target needed `-Wno-quoted-include-in-framework-header` because macOS consumes libobs as a framework; without it the obs headers fail under `-Werror`. Ubuntu (non-framework) is unaffected.

Part of the Tier 1 MVP cluster (#73–#78); blocked-by #73.