### PR TITLE
test(opus): extract OpusHead/OpusTags serializers and cover RFC 7845 layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ target_sources(
     src/radio-output.h
     src/radio-encoder.h
     src/radio-opus-encoder.c
+    src/ogg-opus-headers.c
+    src/ogg-opus-headers.h
     src/reconnect.c
     src/reconnect.h
     src/metadata.c

--- a/src/ogg-opus-headers.c
+++ b/src/ogg-opus-headers.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ogg-opus-headers.h"
+
+#include <string.h>
+
+void opus_format_head(uint8_t out[OPUS_HEAD_SIZE], uint8_t channels, uint16_t pre_skip, uint32_t input_sample_rate)
+{
+	memcpy(out, "OpusHead", 8);
+	out[8] = 1; /* version */
+	out[9] = channels;
+	out[10] = (uint8_t)(pre_skip & 0xFF);
+	out[11] = (uint8_t)((pre_skip >> 8) & 0xFF);
+	out[12] = (uint8_t)(input_sample_rate & 0xFF);
+	out[13] = (uint8_t)((input_sample_rate >> 8) & 0xFF);
+	out[14] = (uint8_t)((input_sample_rate >> 16) & 0xFF);
+	out[15] = (uint8_t)((input_sample_rate >> 24) & 0xFF);
+	out[16] = 0; /* output gain low (0 = unity) */
+	out[17] = 0; /* output gain high */
+	out[18] = 0; /* channel mapping family 0 */
+}
+
+size_t opus_format_tags(uint8_t *out, size_t cap, const char *vendor)
+{
+	const size_t vendor_len = strlen(vendor);
+	const size_t total = 8 + 4 + vendor_len + 4;
+	if (cap < total)
+		return 0;
+
+	memcpy(out, "OpusTags", 8);
+	const uint32_t vlen = (uint32_t)vendor_len;
+	out[8] = (uint8_t)(vlen & 0xFF);
+	out[9] = (uint8_t)((vlen >> 8) & 0xFF);
+	out[10] = (uint8_t)((vlen >> 16) & 0xFF);
+	out[11] = (uint8_t)((vlen >> 24) & 0xFF);
+	memcpy(out + 12, vendor, vendor_len);
+
+	/* user_comment_list_length = 0 (no per-comment data follows) */
+	out[12 + vendor_len + 0] = 0;
+	out[12 + vendor_len + 1] = 0;
+	out[12 + vendor_len + 2] = 0;
+	out[12 + vendor_len + 3] = 0;
+
+	return total;
+}

--- a/src/ogg-opus-headers.h
+++ b/src/ogg-opus-headers.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Pure serializers for the Opus container header packets (RFC 7845).  Split out
+ * of radio-opus-encoder.c so the byte layout can be unit-tested in isolation,
+ * with no libopus / libogg / OBS dependency (issue #75).  The encoder still
+ * owns the ogg_stream packetin/flush plumbing; these only pack bytes.
+ */
+
+/* OpusHead is exactly 19 bytes for channel mapping family 0 (RFC 7845 §5.1). */
+#define OPUS_HEAD_SIZE 19
+
+/*
+ * Serialize an OpusHead packet (RFC 7845 §5.1, channel mapping family 0) into
+ * out[0..OPUS_HEAD_SIZE).  pre_skip and input_sample_rate are written
+ * little-endian per the spec; output gain is fixed at 0 (unity).
+ */
+void opus_format_head(uint8_t out[OPUS_HEAD_SIZE], uint8_t channels, uint16_t pre_skip, uint32_t input_sample_rate);
+
+/*
+ * Serialize an OpusTags packet (RFC 7845 §5.2) carrying the given vendor string
+ * and zero user comments into out[0..cap).  Returns the number of bytes written
+ * (8 + 4 + strlen(vendor) + 4), or 0 if cap is too small.
+ */
+size_t opus_format_tags(uint8_t *out, size_t cap, const char *vendor);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/radio-opus-encoder.c
+++ b/src/radio-opus-encoder.c
@@ -33,6 +33,7 @@
 
 #include "radio-encoder.h"
 #include "radio-output.h"
+#include "ogg-opus-headers.h"
 
 #include <plugin-support.h>
 #include <util/base.h>
@@ -170,20 +171,10 @@ static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_hea
 	*out_headers = NULL;
 	*out_bytes = 0;
 
-	/* ---- OpusHead (RFC 7845 §5.1, 19 bytes for channel mapping family 0) ---- */
-	uint8_t head[19];
-	memcpy(head, "OpusHead", 8);
-	head[8] = 1;                     /* version */
-	head[9] = (uint8_t)st->channels; /* output channel count */
-	head[10] = (uint8_t)(st->preskip & 0xFF);
-	head[11] = (uint8_t)((st->preskip >> 8) & 0xFF);
-	head[12] = (uint8_t)(st->sample_rate & 0xFF);
-	head[13] = (uint8_t)((st->sample_rate >> 8) & 0xFF);
-	head[14] = (uint8_t)((st->sample_rate >> 16) & 0xFF);
-	head[15] = (uint8_t)((st->sample_rate >> 24) & 0xFF);
-	head[16] = 0; /* output gain low (0 = unity) */
-	head[17] = 0; /* output gain high */
-	head[18] = 0; /* channel mapping family */
+	/* ---- OpusHead (RFC 7845 §5.1, 19 bytes for channel mapping family 0) ----
+	 * Byte layout lives in ogg-opus-headers.c so it can be unit-tested. */
+	uint8_t head[OPUS_HEAD_SIZE];
+	opus_format_head(head, (uint8_t)st->channels, (uint16_t)st->preskip, st->sample_rate);
 
 	ogg_packet op_head = {0};
 	op_head.packet = head;
@@ -197,22 +188,13 @@ static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_hea
 		return false;
 	}
 
-	/* ---- OpusTags (RFC 7845 §5.2) ---- */
-	const char *vendor = "obs-radio-output";
-	const size_t vendor_len = strlen(vendor);
-	const size_t tags_len = 8 + 4 + vendor_len + 4;
-	uint8_t *tags = bmalloc(tags_len);
-	memcpy(tags, "OpusTags", 8);
-	const uint32_t vlen32 = (uint32_t)vendor_len;
-	tags[8] = (uint8_t)(vlen32 & 0xFF);
-	tags[9] = (uint8_t)((vlen32 >> 8) & 0xFF);
-	tags[10] = (uint8_t)((vlen32 >> 16) & 0xFF);
-	tags[11] = (uint8_t)((vlen32 >> 24) & 0xFF);
-	memcpy(tags + 12, vendor, vendor_len);
-	tags[12 + vendor_len + 0] = 0;
-	tags[12 + vendor_len + 1] = 0;
-	tags[12 + vendor_len + 2] = 0;
-	tags[12 + vendor_len + 3] = 0;
+	/* ---- OpusTags (RFC 7845 §5.2) ----
+	 * Vendor "obs-radio-output" (16 bytes) → a 32-byte packet; the 64-byte
+	 * stack buffer is ample.  libogg copies the packet bytes in
+	 * ogg_stream_packetin, so the buffer needn't outlive this call.  Byte
+	 * layout lives in ogg-opus-headers.c. */
+	uint8_t tags[64];
+	const size_t tags_len = opus_format_tags(tags, sizeof(tags), "obs-radio-output");
 
 	ogg_packet op_tags = {0};
 	op_tags.packet = tags;
@@ -223,7 +205,6 @@ static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_hea
 	op_tags.packetno = st->packetno++;
 	if (ogg_stream_packetin(&st->os, &op_tags) != 0) {
 		obs_log(LOG_ERROR, "ogg_stream_packetin(OpusTags) failed");
-		bfree(tags);
 		return false;
 	}
 
@@ -235,8 +216,6 @@ static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_hea
 	ogg_page page;
 	while (ogg_stream_flush(&st->os, &page))
 		append_page(&pages, &pages_len, &pages_cap, &page);
-
-	bfree(tags);
 
 	*out_headers = pages;
 	*out_bytes = pages_len;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,9 @@ function(radio_add_test name)
 endfunction()
 
 radio_add_test(test_smoke test_smoke.cpp)
+
+# OpusHead / OpusTags byte-layout test (#75).  Compiles only the pure
+# serializer TU — no libopus / libogg / OBS — so no extra include trees or
+# stubs are needed.
+radio_add_test(test_opus_headers test_opus_headers.cpp ${CMAKE_SOURCE_DIR}/src/ogg-opus-headers.c)
+target_include_directories(test_opus_headers PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/test_opus_headers.cpp
+++ b/tests/test_opus_headers.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Byte-exact tests for the Opus container header serializers (RFC 7845
+// §5.1/§5.2), issue #75.  The serializers were split out of
+// radio-opus-encoder.c into src/ogg-opus-headers.c precisely so they can be
+// tested here with no libopus / libogg / OBS dependency — this target compiles
+// only that one pure C file.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+#include "ogg-opus-headers.h"
+}
+
+namespace {
+uint16_t le16(const uint8_t *p)
+{
+	return static_cast<uint16_t>(p[0] | (p[1] << 8));
+}
+uint32_t le32(const uint8_t *p)
+{
+	return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) | (static_cast<uint32_t>(p[2]) << 16) |
+	       (static_cast<uint32_t>(p[3]) << 24);
+}
+} // namespace
+
+TEST_CASE("OpusHead matches RFC 7845 §5.1 byte layout (stereo)", "[opus][headers]")
+{
+	uint8_t head[OPUS_HEAD_SIZE];
+	opus_format_head(head, /*channels=*/2, /*pre_skip=*/312, /*input_sample_rate=*/48000);
+
+	REQUIRE(std::memcmp(head, "OpusHead", 8) == 0);
+	REQUIRE(head[8] == 1);              // version
+	REQUIRE(head[9] == 2);              // channel count
+	REQUIRE(le16(head + 10) == 312);    // pre-skip, little-endian
+	REQUIRE(le32(head + 12) == 48000u); // input sample rate, little-endian
+	REQUIRE(le16(head + 16) == 0);      // output gain (unity)
+	REQUIRE(head[18] == 0);             // channel mapping family 0
+}
+
+TEST_CASE("OpusHead encodes mono channel count", "[opus][headers]")
+{
+	uint8_t head[OPUS_HEAD_SIZE];
+	opus_format_head(head, /*channels=*/1, /*pre_skip=*/0, /*input_sample_rate=*/48000);
+	REQUIRE(head[9] == 1);
+	REQUIRE(le16(head + 10) == 0);
+}
+
+TEST_CASE("OpusHead writes pre-skip and sample rate little-endian", "[opus][headers]")
+{
+	uint8_t head[OPUS_HEAD_SIZE];
+	// Values with distinct bytes per position catch endianness/offset slips.
+	opus_format_head(head, 2, 0x1234, 0x0A0B0C0Du);
+	REQUIRE(head[10] == 0x34);
+	REQUIRE(head[11] == 0x12);
+	REQUIRE(head[12] == 0x0D);
+	REQUIRE(head[13] == 0x0C);
+	REQUIRE(head[14] == 0x0B);
+	REQUIRE(head[15] == 0x0A);
+}
+
+TEST_CASE("OpusTags matches RFC 7845 §5.2 byte layout", "[opus][headers]")
+{
+	const char *vendor = "obs-radio-output";
+	const size_t vendor_len = std::strlen(vendor);
+
+	uint8_t tags[64];
+	const size_t n = opus_format_tags(tags, sizeof(tags), vendor);
+
+	REQUIRE(n == 8 + 4 + vendor_len + 4);
+	REQUIRE(std::memcmp(tags, "OpusTags", 8) == 0);
+	REQUIRE(le32(tags + 8) == static_cast<uint32_t>(vendor_len));
+	REQUIRE(std::memcmp(tags + 12, vendor, vendor_len) == 0);
+	REQUIRE(le32(tags + 12 + vendor_len) == 0u); // user comment count
+}
+
+TEST_CASE("OpusTags reports 0 when the buffer is too small", "[opus][headers]")
+{
+	uint8_t tiny[4];
+	REQUIRE(opus_format_tags(tiny, sizeof(tiny), "obs-radio-output") == 0);
+}


### PR DESCRIPTION
**Summary**

Tier 1 MVP step #75 — the highest-value unit test in the cluster: byte-exact coverage of the Opus container headers (RFC 7845 §5.1/§5.2). Per the design decision, the serializers are **extracted into a pure translation unit** so the test needs no libopus/libogg/OBS dependency (cleaner boundary than an in-place test seam). Blocked-by #73 (merged).

- `src/ogg-opus-headers.{c,h}` (new) — pure `opus_format_head()` (19-byte OpusHead, family 0) and `opus_format_tags()` (OpusTags with vendor + zero comments). Only `<string.h>` / `<stdint.h>`; no obs/opus/ogg.
- `src/radio-opus-encoder.c` — `emit_opus_container_headers()` now calls the two serializers instead of packing bytes inline. **Behavior-preserving**: the same bytes are produced. Bonus cleanup — OpusTags no longer needs a `bmalloc`/`bfree` (a 64-byte stack buffer suffices, since `ogg_stream_packetin` copies the packet).
- `tests/test_opus_headers.cpp` — asserts magic strings, version, channel count (mono + stereo), little-endian pre-skip + sample rate (distinct-byte values catch offset/endianness slips), output gain, mapping family, vendor length/string, comment count, and the too-small-buffer guard.
- `CMakeLists.txt` adds the new sources to the plugin; `tests/CMakeLists.txt` registers `test_opus_headers` (compiles only the pure TU — no extra includes or stubs).

**Test plan — ✅ verified locally (macOS arm64)**
- [x] Local: plugin (with the refactor) builds under `-Werror`; `ctest` → `6/6 passed` (smoke + 5 opus-header cases)
- [ ] macOS + Ubuntu CI build + `ctest` green; Windows build green (unaffected)
- [ ] clang-format + gersemi + Conventional Commits green

The opus byte output is unchanged by construction, so no manual acceptance is required; a quick "Opus still streams" smoke is welcome but optional. Part of the Tier 1 cluster (#73–#78).