### PR TITLE
refactor(send): extract send-buf ring buffer into its own translation unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ target_sources(
     src/plugin-main.c
     src/radio-output.c
     src/radio-output.h
+    src/send-buf.c
+    src/send-buf.h
     src/radio-encoder.h
     src/radio-opus-encoder.c
     src/ogg-opus-headers.c

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -104,7 +104,7 @@ static void radio_output_teardown(struct radio_output *context)
 #ifdef HAVE_LIBSHOUT
 	/* Stop the send thread before flushing / closing shout so the thread
 	 * can't race with our flush shout_send. */
-	if (context->send_buf) {
+	if (context->send_buf.data) {
 		context->send_running = false;
 		pthread_mutex_lock(&context->send_mutex);
 		pthread_cond_signal(&context->send_cond);
@@ -112,8 +112,7 @@ static void radio_output_teardown(struct radio_output *context)
 		pthread_join(context->send_thread, NULL);
 		pthread_mutex_destroy(&context->send_mutex);
 		pthread_cond_destroy(&context->send_cond);
-		bfree(context->send_buf);
-		context->send_buf = NULL;
+		radio_send_buf_free(&context->send_buf);
 		obs_log(LOG_INFO, "Encoder send thread stopped");
 	}
 
@@ -278,25 +277,14 @@ static void *encoder_send_thread(void *data)
 
 	while (context->send_running) {
 		pthread_mutex_lock(&context->send_mutex);
-		while (context->send_wpos == context->send_rpos && context->send_running)
+		while (radio_send_buf_used(&context->send_buf) == 0 && context->send_running)
 			pthread_cond_wait(&context->send_cond, &context->send_mutex);
 		if (!context->send_running) {
 			pthread_mutex_unlock(&context->send_mutex);
 			break;
 		}
 
-		size_t avail = context->send_wpos - context->send_rpos;
-		size_t to_read = avail < sizeof(scratch) ? avail : sizeof(scratch);
-		size_t rpos = context->send_rpos % SEND_BUF_CAPACITY;
-		size_t tail = SEND_BUF_CAPACITY - rpos;
-
-		if (tail >= to_read) {
-			memcpy(scratch, context->send_buf + rpos, to_read);
-		} else {
-			memcpy(scratch, context->send_buf + rpos, tail);
-			memcpy(scratch + tail, context->send_buf, to_read - tail);
-		}
-		context->send_rpos += to_read;
+		size_t to_read = radio_send_buf_read(&context->send_buf, scratch, sizeof(scratch));
 		pthread_mutex_unlock(&context->send_mutex);
 
 		if (!context->shout)
@@ -335,25 +323,13 @@ static void *encoder_send_thread(void *data)
  */
 static void send_buf_push(struct radio_output *context, const uint8_t *bytes, size_t len)
 {
-	if (!context->send_buf || len == 0)
+	if (!context->send_buf.data || len == 0)
 		return;
 
 	pthread_mutex_lock(&context->send_mutex);
-	size_t used = context->send_wpos - context->send_rpos;
-	if (used + len > SEND_BUF_CAPACITY) {
-		size_t drop = used + len - SEND_BUF_CAPACITY;
-		context->send_rpos += drop;
-		obs_log(LOG_WARNING, "send buffer full, dropped %zu bytes", drop);
-	}
-	size_t wpos = context->send_wpos % SEND_BUF_CAPACITY;
-	size_t tail = SEND_BUF_CAPACITY - wpos;
-	if (tail >= len) {
-		memcpy(context->send_buf + wpos, bytes, len);
-	} else {
-		memcpy(context->send_buf + wpos, bytes, tail);
-		memcpy(context->send_buf, bytes + tail, len - tail);
-	}
-	context->send_wpos += len;
+	size_t dropped = radio_send_buf_push(&context->send_buf, bytes, len);
+	if (dropped)
+		obs_log(LOG_WARNING, "send buffer full, dropped %zu bytes", dropped);
 	pthread_cond_signal(&context->send_cond);
 	pthread_mutex_unlock(&context->send_mutex);
 }
@@ -614,26 +590,26 @@ static bool radio_output_start(void *data)
 	}
 
 	/* --- Start shared send thread (all codecs) --- */
-	uint8_t *sbuf = bmalloc(SEND_BUF_CAPACITY);
-	if (!sbuf) {
-		obs_log(LOG_ERROR, "Failed to allocate send buffer");
-		bfree(startup_bytes);
-		goto start_fail_after_capture;
-	}
-	/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio. */
-	context->send_wpos = 0;
-	context->send_rpos = 0;
+	/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio;
+	 * radio_send_buf_init sets the data pointer last, so raw_audio's
+	 * send_buf.data "ready" gate only opens once the buffer is usable. */
 	context->send_running = true;
 	pthread_mutex_init(&context->send_mutex, NULL);
 	pthread_cond_init(&context->send_cond, NULL);
-	context->send_buf = sbuf; /* raw_audio uses this as its "ready" gate */
+	if (!radio_send_buf_init(&context->send_buf, SEND_BUF_CAPACITY)) {
+		obs_log(LOG_ERROR, "Failed to allocate send buffer");
+		context->send_running = false;
+		pthread_mutex_destroy(&context->send_mutex);
+		pthread_cond_destroy(&context->send_cond);
+		bfree(startup_bytes);
+		goto start_fail_after_capture;
+	}
 	if (pthread_create(&context->send_thread, NULL, encoder_send_thread, context) != 0) {
 		obs_log(LOG_ERROR, "Failed to create encoder send thread");
 		context->send_running = false;
-		context->send_buf = NULL;
+		radio_send_buf_free(&context->send_buf);
 		pthread_mutex_destroy(&context->send_mutex);
 		pthread_cond_destroy(&context->send_cond);
-		bfree(sbuf);
 		bfree(startup_bytes);
 		goto start_fail_after_capture;
 	}
@@ -677,10 +653,10 @@ static void radio_output_raw_audio(void *data, struct audio_data *frames)
 	if (!frames || !frames->frames)
 		return;
 
-	/* send_buf doubles as the "ready to write" gate — set by start() only
-	 * after mutex/cond/send thread are all live.  encoder is set one step
-	 * earlier, so both null-checks matter. */
-	if (!context->encoder || !context->send_buf)
+	/* send_buf.data doubles as the "ready to write" gate — set by start()
+	 * (radio_send_buf_init) only after mutex/cond/send thread are all live.
+	 * encoder is set one step earlier, so both null-checks matter. */
+	if (!context->encoder || !context->send_buf.data)
 		return;
 
 	const float *left = (const float *)frames->data[0];

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "send-buf.h"
+
 #ifdef HAVE_LIBSHOUT
 #include <shout/shout.h>
 #endif
@@ -90,12 +92,12 @@ struct radio_output {
 	 * Shared sender thread.  The encoder writes compressed bytes into
 	 * send_buf from the audio thread; this thread drains them to libshout
 	 * with shout_sync() pacing.  Originally MP3-only (hence the naming in
-	 * older logs); now generic across MP3 and Opus.
+	 * older logs); now generic across MP3 and Opus.  The ring buffer itself
+	 * lives in send-buf.{c,h}; send_mutex serializes producer/consumer access
+	 * to it (see send_buf_push and encoder_send_thread).
 	 */
 #define SEND_BUF_CAPACITY (256 * 1024) /* 256 KB ≈ 14 s at 128 kbps */
-	uint8_t *send_buf;
-	size_t send_wpos; /* monotonically increasing write position */
-	size_t send_rpos; /* monotonically increasing read position */
+	struct radio_send_buf send_buf;
 	pthread_mutex_t send_mutex;
 	pthread_cond_t send_cond;
 	pthread_t send_thread;

--- a/src/send-buf.c
+++ b/src/send-buf.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "send-buf.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+bool radio_send_buf_init(struct radio_send_buf *sb, size_t capacity)
+{
+	sb->capacity = capacity;
+	sb->wpos = 0;
+	sb->rpos = 0;
+	sb->data = malloc(capacity); /* set last — it is the reader's "ready" gate */
+	return sb->data != NULL;
+}
+
+void radio_send_buf_free(struct radio_send_buf *sb)
+{
+	free(sb->data);
+	sb->data = NULL;
+	sb->capacity = 0;
+	sb->wpos = 0;
+	sb->rpos = 0;
+}
+
+size_t radio_send_buf_used(const struct radio_send_buf *sb)
+{
+	return sb->wpos - sb->rpos;
+}
+
+size_t radio_send_buf_push(struct radio_send_buf *sb, const uint8_t *bytes, size_t len)
+{
+	if (!sb->data || sb->capacity == 0 || len == 0)
+		return 0;
+
+	size_t dropped = 0;
+	size_t used = sb->wpos - sb->rpos;
+	if (used + len > sb->capacity) {
+		dropped = used + len - sb->capacity;
+		sb->rpos += dropped;
+	}
+
+	size_t wpos = sb->wpos % sb->capacity;
+	size_t tail = sb->capacity - wpos;
+	if (tail >= len) {
+		memcpy(sb->data + wpos, bytes, len);
+	} else {
+		memcpy(sb->data + wpos, bytes, tail);
+		memcpy(sb->data, bytes + tail, len - tail);
+	}
+	sb->wpos += len;
+	return dropped;
+}
+
+size_t radio_send_buf_read(struct radio_send_buf *sb, uint8_t *dst, size_t max)
+{
+	if (!sb->data || sb->capacity == 0)
+		return 0;
+
+	size_t avail = sb->wpos - sb->rpos;
+	size_t to_read = avail < max ? avail : max;
+	if (to_read == 0)
+		return 0;
+
+	size_t rpos = sb->rpos % sb->capacity;
+	size_t tail = sb->capacity - rpos;
+	if (tail >= to_read) {
+		memcpy(dst, sb->data + rpos, to_read);
+	} else {
+		memcpy(dst, sb->data + rpos, tail);
+		memcpy(dst + tail, sb->data, to_read - tail);
+	}
+	sb->rpos += to_read;
+	return to_read;
+}

--- a/src/send-buf.h
+++ b/src/send-buf.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Byte ring buffer with FIFO drop-oldest on overflow, extracted from
+ * radio-output.c (issue #77) so the wraparound and drop semantics can be
+ * unit-tested in isolation.
+ *
+ * NOT thread-safe on its own: radio-output.c serializes the producer (audio
+ * thread, via send_buf_push) and the consumer (send thread) with its existing
+ * send_mutex.  wpos/rpos are monotonically increasing counters; the live byte
+ * count is wpos - rpos.  Operations no-op when data is NULL or capacity is 0 so
+ * a not-yet-initialized buffer (the audio callback's "ready" gate is the data
+ * pointer) is always safe to call into.
+ */
+struct radio_send_buf {
+	uint8_t *data;
+	size_t capacity;
+	size_t wpos; /* monotonically increasing write position */
+	size_t rpos; /* monotonically increasing read position */
+};
+
+/*
+ * Allocate the backing buffer of `capacity` bytes.  capacity/wpos/rpos are set
+ * before data so that, once a reader observes a non-NULL data pointer, the
+ * other fields are already populated.  Returns false if allocation fails.
+ */
+bool radio_send_buf_init(struct radio_send_buf *sb, size_t capacity);
+
+/* Free the backing buffer and reset all fields (data left NULL). */
+void radio_send_buf_free(struct radio_send_buf *sb);
+
+/* Bytes currently buffered (wpos - rpos). */
+size_t radio_send_buf_used(const struct radio_send_buf *sb);
+
+/*
+ * Append len bytes, dropping the oldest data if the buffer would overflow.
+ * Returns the number of oldest bytes dropped (0 in the common case) so the
+ * caller can log.  No-op (returns 0) when the buffer is uninitialized or len 0.
+ */
+size_t radio_send_buf_push(struct radio_send_buf *sb, const uint8_t *bytes, size_t len);
+
+/*
+ * Copy up to max bytes of buffered data into dst, advancing the read position.
+ * Returns the number of bytes copied.
+ */
+size_t radio_send_buf_read(struct radio_send_buf *sb, uint8_t *dst, size_t max);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
**Summary**

Tier 1 MVP step #77 — extracts the 256 KB send-buffer ring out of `radio-output.c` into `src/send-buf.{c,h}` so it has a clean unit boundary (#78 tests it next). Behavior-preserving; blocked-by #73 (merged), and **blocks #78**.

- `src/send-buf.{c,h}` (new) — `struct radio_send_buf` + pure (lock-free) `radio_send_buf_init/free/used/push/read`. `push` keeps the exact FIFO drop-oldest + wraparound semantics from the original and returns the dropped-byte count so the caller logs. No OBS/libshout dependency (uses `malloc`/`free`), so #78 can test it with zero stubs.
- `radio-output.c` — `struct radio_output` now embeds `struct radio_send_buf send_buf` (replacing the raw `uint8_t *send_buf` + `send_wpos`/`send_rpos`). `send_buf_push` (the locking wrapper), `encoder_send_thread` (the consumer), `radio_output_teardown`, and the start path all call through the new API. `send_mutex`/`send_cond`/`send_thread`/`send_running` stay in `radio-output.c` — only the ring math moved.

**Semantics preserved + hardened**
- The audio-callback "ready" gate is still the data pointer (`send_buf.data`); `radio_send_buf_init` sets `data` **last** (after capacity/wpos/rpos) so the gate only opens once the buffer is usable. `begin_data_capture` runs before this setup, so that ordering matters.
- `push`/`read` no-op when `data == NULL` **or** `capacity == 0`, eliminating any divide-by-zero if a reader observed `data` before `capacity` (the original was safe only because `SEND_BUF_CAPACITY` was a compile-time constant; now it's a field).

**Test plan**
- [x] Local arm64 build clean under `-Werror`; plugin links (`** BUILD SUCCEEDED **`)
- [ ] CI: macOS + Ubuntu + Windows builds green; CodeQL + Clang-Tidy + format green
- [ ] **Manual smoke (Aaron, per acceptance):** Start broadcast → stream ~60 s to local Icecast → VLC plays cleanly → Stop. Logs should match a pre-refactor session line-for-line (modulo timestamps): `Encoder send thread started`, clean audio, `Encoder send thread stopped`, single `Disconnected`. No `send buffer full` spam under normal load.

Once this merges, #78 (`test/4-ring-buffer`) adds the wraparound / drop-oldest unit tests against `send-buf.h`, closing the Tier 1 cluster.