### PR TITLE
test(send): cover send-buf ring wraparound and drop-oldest semantics

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,3 +81,8 @@ target_include_directories(
   PRIVATE ${CMAKE_SOURCE_DIR}/src $<TARGET_PROPERTY:OBS::libobs,INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_link_libraries(test_opus_accumulator PRIVATE LibOpus::LibOpus LibOgg::LibOgg)
+
+# send-buf ring-buffer test (#78).  send-buf.c is pure (malloc/free, no
+# OBS/libshout), so it links straight in with no stubs or extra includes.
+radio_add_test(test_ring_buffer test_ring_buffer.cpp ${CMAKE_SOURCE_DIR}/src/send-buf.c)
+target_include_directories(test_ring_buffer PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/test_ring_buffer.cpp
+++ b/tests/test_ring_buffer.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ring-buffer wraparound + FIFO drop-oldest tests (issue #78) for the send-buf
+// module extracted in #77.  send-buf.c is pure (no OBS/libshout), so this links
+// it directly with no stubs.  Small capacities make the boundary math explicit.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+extern "C" {
+#include "send-buf.h"
+}
+
+namespace {
+std::vector<uint8_t> seq(uint8_t start, size_t n)
+{
+	std::vector<uint8_t> v(n);
+	for (size_t i = 0; i < n; i++)
+		v[i] = static_cast<uint8_t>(start + i);
+	return v;
+}
+
+// Push then read everything currently buffered; returns the bytes read back.
+std::vector<uint8_t> read_all(radio_send_buf *sb)
+{
+	std::vector<uint8_t> out(radio_send_buf_used(sb));
+	const size_t n = radio_send_buf_read(sb, out.data(), out.size());
+	out.resize(n);
+	return out;
+}
+} // namespace
+
+TEST_CASE("a freshly initialized buffer is empty", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	REQUIRE(radio_send_buf_used(&sb) == 0);
+	uint8_t dst[4];
+	REQUIRE(radio_send_buf_read(&sb, dst, sizeof(dst)) == 0);
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("a write that does not wrap round-trips intact", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	const auto in = seq(1, 4);
+	REQUIRE(radio_send_buf_push(&sb, in.data(), in.size()) == 0);
+	REQUIRE(radio_send_buf_used(&sb) == 4);
+	REQUIRE(read_all(&sb) == in);
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("a write that wraps mid-payload reassembles in order", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	// Advance read/write positions to 6 so the next write straddles the end.
+	const auto warmup = seq(100, 6);
+	radio_send_buf_push(&sb, warmup.data(), warmup.size());
+	(void)read_all(&sb); // drain; rpos == wpos == 6
+	REQUIRE(radio_send_buf_used(&sb) == 0);
+
+	const auto in = seq(1, 4); // writes at indices 6,7,0,1 — wraps
+	REQUIRE(radio_send_buf_push(&sb, in.data(), in.size()) == 0);
+	REQUIRE(radio_send_buf_used(&sb) == 4);
+	REQUIRE(read_all(&sb) == in);
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("a write that exactly fills the buffer keeps all bytes", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	const auto in = seq(1, 8);
+	REQUIRE(radio_send_buf_push(&sb, in.data(), in.size()) == 0);
+	REQUIRE(radio_send_buf_used(&sb) == 8);
+	REQUIRE(read_all(&sb) == in);
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("overflow by one byte drops exactly the oldest byte", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	const auto first = seq(1, 8); // fills
+	REQUIRE(radio_send_buf_push(&sb, first.data(), first.size()) == 0);
+
+	const uint8_t extra = 99;
+	REQUIRE(radio_send_buf_push(&sb, &extra, 1) == 1); // one oldest byte dropped
+	REQUIRE(radio_send_buf_used(&sb) == 8);
+
+	// Oldest (1) is gone; buffer now holds 2..8 then 99.
+	std::vector<uint8_t> expected = {2, 3, 4, 5, 6, 7, 8, 99};
+	REQUIRE(read_all(&sb) == expected);
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("a payload larger than capacity keeps only the newest capacity bytes", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	const auto fill = seq(1, 8);
+	radio_send_buf_push(&sb, fill.data(), fill.size());
+
+	// 12-byte payload into an 8-byte buffer: drop = used(8)+len(12)-cap(8) = 12.
+	const auto big = seq(20, 12); // 20..31
+	REQUIRE(radio_send_buf_push(&sb, big.data(), big.size()) == 12);
+	REQUIRE(radio_send_buf_used(&sb) == 8);
+
+	// Only the newest 8 bytes of the 12-byte payload survive (24..31).
+	REQUIRE(read_all(&sb) == seq(24, 8));
+	radio_send_buf_free(&sb);
+}
+
+TEST_CASE("a partial read advances the read position", "[ring]")
+{
+	radio_send_buf sb;
+	REQUIRE(radio_send_buf_init(&sb, 8));
+	const auto in = seq(1, 6);
+	radio_send_buf_push(&sb, in.data(), in.size());
+
+	uint8_t dst[2];
+	REQUIRE(radio_send_buf_read(&sb, dst, 2) == 2);
+	REQUIRE(dst[0] == 1);
+	REQUIRE(dst[1] == 2);
+	REQUIRE(radio_send_buf_used(&sb) == 4);
+	REQUIRE(read_all(&sb) == seq(3, 4));
+	radio_send_buf_free(&sb);
+}


### PR DESCRIPTION
**Summary**

Final step of the Tier 1 testing MVP (issue #78) — unit tests for the `send-buf` ring extracted in #77. Closes the #73–#78 cluster.

> ⚠️ **Stacked on #77** (`base: refactor/extract-send-buf`). Do not merge until #77 lands; GitHub will retarget this to `main` automatically when #77 merges, after which it shows only its own diff.

- `tests/test_ring_buffer.cpp` — tests the public `radio_send_buf_*` API with small capacities so the boundary math is explicit: empty buffer, non-wrapping write, write that wraps mid-payload, exact-fill, overflow-by-one (drops exactly the oldest byte), payload larger than capacity (keeps only the newest `capacity` bytes), and partial read advancing the read position.
- `tests/CMakeLists.txt` — registers `test_ring_buffer`; links `src/send-buf.c` directly (pure, no stubs/includes needed).

No production-code changes (the boundary was created by #77).

**Test plan**
- [x] Local: `All tests passed (31 assertions in 7 test cases)` (run directly; the full `ctest` is unaffected by the libopus/libogg local-signing quirk since this test has no dylib deps)
- [ ] macOS + Ubuntu CI build + `ctest` green; Windows build green (unaffected)
- [ ] clang-format + gersemi + commit-lint green

Part of the Tier 1 cluster (#73–#78) — this is the last one.