### PR TITLE
feat(obs-ws): add obs-websocket vendor API with read-only radio.status

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -24,7 +24,9 @@ runs:
       uses: ./.github/actions/check-changes
       id: checks
       with:
-        checkGlob: "'*.c' '*.h' '*.cpp' '*.hpp' '*.m' '*.mm'"
+        # ':!deps' excludes vendored third-party sources (e.g. deps/obs-websocket-api)
+        # from the style check — we keep upstream formatting rather than restyle it.
+        checkGlob: "'*.c' '*.h' '*.cpp' '*.hpp' '*.m' '*.mm' ':!deps'"
         diffFilter: 'ACM'
 
     - name: Install Dependencies 🛍️

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !/build-aux
 !/cmake
 !/data
+!/deps
 !/docs
 !/scripts
 !/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(${CMAKE_PROJECT_NAME} MODULE)
 find_package(libobs REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::libobs)
 
+# Vendored obs-websocket plugin API (single header, runtime proc-handler based —
+# no link dependency on obs-websocket; registration is a no-op when it's absent).
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps/obs-websocket-api")
+
 if(WIN32)
   # MSVC cannot link MinGW-built libraries; make libshout optional on Windows
   # until MSVC-compatible binaries are available.
@@ -129,6 +133,8 @@ target_sources(
   ${CMAKE_PROJECT_NAME}
   PRIVATE
     src/plugin-main.c
+    src/obs-ws-vendor.c
+    src/obs-ws-vendor.h
     src/radio-output.c
     src/radio-output.h
     src/radio-encoder.h

--- a/deps/obs-websocket-api/obs-websocket-api.h
+++ b/deps/obs-websocket-api/obs-websocket-api.h
@@ -1,0 +1,259 @@
+/*
+obs-websocket
+Copyright (C) 2016-2021 Stephane Lepin <stephane.lepin@gmail.com>
+Copyright (C) 2020-2022 Kyle Manning <tt2468@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#ifndef _OBS_WEBSOCKET_API_H
+#define _OBS_WEBSOCKET_API_H
+
+#include <obs.h>
+
+#define OBS_WEBSOCKET_API_VERSION 3
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *obs_websocket_vendor;
+typedef void (*obs_websocket_request_callback_function)(obs_data_t *, obs_data_t *, void *);
+typedef void (*obs_websocket_event_callback_function)(uint64_t, const char *, const char *, void *);
+
+struct obs_websocket_request_response {
+	unsigned int status_code;
+	char *comment;
+	char *response_data; // JSON string, because obs_data_t* only supports array<object>, so conversions would break API.
+};
+
+/* ==================== INTERNAL DEFINITIONS ==================== */
+
+struct obs_websocket_request_callback {
+	obs_websocket_request_callback_function callback;
+	void *priv_data;
+};
+
+struct obs_websocket_event_callback {
+	obs_websocket_event_callback_function callback;
+	void *priv_data;
+};
+
+static proc_handler_t *_ph;
+
+/* ==================== INTERNAL API FUNCTIONS ==================== */
+
+static inline proc_handler_t *obs_websocket_get_ph(void)
+{
+	proc_handler_t *global_ph = obs_get_proc_handler();
+	assert(global_ph != NULL);
+
+	calldata_t cd = {0, 0, 0, 0};
+	if (!proc_handler_call(global_ph, "obs_websocket_api_get_ph", &cd))
+		blog(LOG_DEBUG, "Unable to fetch obs-websocket proc handler object. obs-websocket not installed?");
+	proc_handler_t *ret = (proc_handler_t *)calldata_ptr(&cd, "ph");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+static inline bool obs_websocket_ensure_ph(void)
+{
+	if (!_ph)
+		_ph = obs_websocket_get_ph();
+	return _ph != NULL;
+}
+
+static inline bool obs_websocket_vendor_run_simple_proc(obs_websocket_vendor vendor, const char *proc_name, calldata_t *cd)
+{
+	if (!obs_websocket_ensure_ph())
+		return false;
+
+	if (!vendor || !proc_name || !strlen(proc_name) || !cd)
+		return false;
+
+	calldata_set_ptr(cd, "vendor", vendor);
+
+	proc_handler_call(_ph, proc_name, cd);
+	return calldata_bool(cd, "success");
+}
+
+/* ==================== GENERAL API FUNCTIONS ==================== */
+
+// Gets the API version built with the obs-websocket plugin
+static inline unsigned int obs_websocket_get_api_version(void)
+{
+	if (!obs_websocket_ensure_ph())
+		return 0;
+
+	calldata_t cd = {0, 0, 0, 0};
+
+	if (!proc_handler_call(_ph, "get_api_version", &cd))
+		return 1; // API v1 does not include get_api_version
+
+	unsigned int ret = (unsigned int)calldata_int(&cd, "version");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Calls an obs-websocket request. Free response with `obs_websocket_request_response_free()`
+static inline struct obs_websocket_request_response *obs_websocket_call_request(const char *request_type, obs_data_t *request_data
+#ifdef __cplusplus
+													  = NULL
+#endif
+)
+{
+	if (!obs_websocket_ensure_ph())
+		return NULL;
+
+	const char *request_data_string = NULL;
+	if (request_data)
+		request_data_string = obs_data_get_json(request_data);
+
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_string(&cd, "request_type", request_type);
+	calldata_set_string(&cd, "request_data", request_data_string);
+
+	proc_handler_call(_ph, "call_request", &cd);
+
+	struct obs_websocket_request_response *ret = (struct obs_websocket_request_response *)calldata_ptr(&cd, "response");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Free a request response object returned by `obs_websocket_call_request()`
+static inline void obs_websocket_request_response_free(struct obs_websocket_request_response *response)
+{
+	if (!response)
+		return;
+
+	if (response->comment)
+		bfree(response->comment);
+	if (response->response_data)
+		bfree(response->response_data);
+	bfree(response);
+}
+
+// Register an event handler to receive obs-websocket events
+static inline bool obs_websocket_register_event_callback(obs_websocket_event_callback_function event_callback, void *priv_data)
+{
+	if (!obs_websocket_ensure_ph())
+		return false;
+
+	struct obs_websocket_event_callback cb = {event_callback, priv_data};
+
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_ptr(&cd, "callback", &cb);
+
+	proc_handler_call(_ph, "register_event_callback", &cd);
+
+	bool ret = calldata_bool(&cd, "success");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Unregister an existing event handler
+static inline bool obs_websocket_unregister_event_callback(obs_websocket_event_callback_function event_callback, void *priv_data)
+{
+	if (!obs_websocket_ensure_ph())
+		return false;
+
+	struct obs_websocket_event_callback cb = {event_callback, priv_data};
+
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_ptr(&cd, "callback", &cb);
+
+	proc_handler_call(_ph, "unregister_event_callback", &cd);
+
+	bool ret = calldata_bool(&cd, "success");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+/* ==================== VENDOR API FUNCTIONS ==================== */
+
+// ALWAYS CALL ONLY VIA `obs_module_post_load()` CALLBACK!
+// Registers a new "vendor" (Example: obs-ndi)
+static inline obs_websocket_vendor obs_websocket_register_vendor(const char *vendor_name)
+{
+	if (!obs_websocket_ensure_ph())
+		return NULL;
+
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_string(&cd, "name", vendor_name);
+
+	proc_handler_call(_ph, "vendor_register", &cd);
+	obs_websocket_vendor ret = calldata_ptr(&cd, "vendor");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Registers a new request for a vendor
+static inline bool obs_websocket_vendor_register_request(obs_websocket_vendor vendor, const char *request_type,
+							 obs_websocket_request_callback_function request_callback, void *priv_data)
+{
+	struct obs_websocket_request_callback cb = {request_callback, priv_data};
+
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_string(&cd, "type", request_type);
+	calldata_set_ptr(&cd, "callback", &cb);
+
+	bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_request_register", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Unregisters an existing vendor request
+static inline bool obs_websocket_vendor_unregister_request(obs_websocket_vendor vendor, const char *request_type)
+{
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_string(&cd, "type", request_type);
+
+	bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_request_unregister", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Does not affect event_data refcount.
+// Emits an event under the vendor's name
+static inline bool obs_websocket_vendor_emit_event(obs_websocket_vendor vendor, const char *event_name, obs_data_t *event_data)
+{
+	calldata_t cd = {0, 0, 0, 0};
+	calldata_set_string(&cd, "type", event_name);
+	calldata_set_ptr(&cd, "data", (void *)event_data);
+
+	bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_event_emit", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+/* ==================== END API FUNCTIONS ==================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/obs-ws-vendor.c
+++ b/src/obs-ws-vendor.c
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include "obs-ws-vendor.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+
+#include <obs-frontend-api.h>
+#include <obs-module.h>
+#include <plugin-support.h>
+
+#include "frontend-wire.h"
+#include "radio-output.h"
+
+/* Single-translation-unit header: defines a static proc-handler cache, so it
+ * must be included in exactly one .c file (this one). */
+#include "obs-websocket-api.h"
+
+#define VENDOR_NAME      "obs-radio-output"
+#define REQUEST_STATUS   "radio.status"
+
+/* obs-websocket vendor handle.  NULL until OBS_FRONTEND_EVENT_FINISHED_LOADING
+ * registers it, or permanently NULL if obs-websocket is not installed. */
+static obs_websocket_vendor s_vendor = NULL;
+
+static const char *state_to_string(radio_state_t state)
+{
+	switch (state) {
+	case RADIO_STATE_DISCONNECTED:
+		return "disconnected";
+	case RADIO_STATE_CONNECTING:
+		return "connecting";
+	case RADIO_STATE_CONNECTED:
+		return "connected";
+	case RADIO_STATE_RECONNECTING:
+		return "reconnecting";
+	case RADIO_STATE_ERROR:
+		return "error";
+	}
+	return "unknown";
+}
+
+static const char *codec_to_string(int codec)
+{
+	switch (codec) {
+	case RADIO_CODEC_OPUS:
+		return "opus";
+	case RADIO_CODEC_MP3:
+		return "mp3";
+	case RADIO_CODEC_VORBIS:
+		return "vorbis";
+	}
+	return "unknown";
+}
+
+static const char *protocol_to_string(int protocol)
+{
+	switch (protocol) {
+	case RADIO_PROTOCOL_ICECAST:
+		return "icecast";
+	case RADIO_PROTOCOL_SHOUTCAST:
+		return "shoutcast";
+	}
+	return "unknown";
+}
+
+/*
+ * radio.status — read-only.  Reports the live connection state and target when
+ * an output is running, otherwise the saved configuration (so a caller can see
+ * what a start would use).  No side effects, so it answers inline on the
+ * obs-websocket thread.
+ *
+ * Response fields:
+ *   outputActive (bool)   — is a radio output instantiated right now
+ *   state        (string) — disconnected|connecting|connected|reconnecting|error
+ *   host         (string)
+ *   port         (int)
+ *   mount        (string)
+ *   codec        (string) — mp3|opus|vorbis|unknown
+ *   bitrate      (int)    — kbps
+ *   tls          (bool)
+ *   protocol     (string) — icecast|shoutcast|unknown
+ *   source       (string) — "active" (fields reflect the running output) or
+ *                           "config" (fields reflect the saved configuration)
+ */
+static void radio_status_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(request_data);
+	UNUSED_PARAMETER(priv_data);
+
+	struct radio_output *ctx = radio_output_get_active();
+	if (ctx) {
+		/* Mirror the dock's pollState() read: hold state_mutex while
+		 * copying the connection fields.  obs_data_set_string copies the
+		 * string internally, so populating the response under the lock
+		 * keeps host/mount valid for the duration of the read. */
+		pthread_mutex_lock(&ctx->state_mutex);
+		obs_data_set_bool(response_data, "outputActive", true);
+		obs_data_set_string(response_data, "state", state_to_string(ctx->state));
+		obs_data_set_string(response_data, "host", ctx->host ? ctx->host : "");
+		obs_data_set_int(response_data, "port", ctx->port);
+		obs_data_set_string(response_data, "mount", ctx->mount ? ctx->mount : "");
+		obs_data_set_string(response_data, "codec", codec_to_string(ctx->codec));
+		obs_data_set_int(response_data, "bitrate", ctx->bitrate);
+		obs_data_set_bool(response_data, "tls", ctx->use_tls);
+		obs_data_set_string(response_data, "protocol", protocol_to_string(ctx->protocol));
+		pthread_mutex_unlock(&ctx->state_mutex);
+		obs_data_set_string(response_data, "source", "active");
+		return;
+	}
+
+	obs_data_t *cfg = frontend_wire_get_config();
+	obs_data_set_bool(response_data, "outputActive", false);
+	obs_data_set_string(response_data, "state", state_to_string(RADIO_STATE_DISCONNECTED));
+	if (cfg) {
+		obs_data_set_string(response_data, "host", obs_data_get_string(cfg, SETTING_HOST));
+		obs_data_set_int(response_data, "port", obs_data_get_int(cfg, SETTING_PORT));
+		obs_data_set_string(response_data, "mount", obs_data_get_string(cfg, SETTING_MOUNT));
+		obs_data_set_string(response_data, "codec", codec_to_string((int)obs_data_get_int(cfg, SETTING_CODEC)));
+		obs_data_set_int(response_data, "bitrate", obs_data_get_int(cfg, SETTING_BITRATE));
+		obs_data_set_bool(response_data, "tls", obs_data_get_bool(cfg, SETTING_TLS));
+		obs_data_set_string(response_data, "protocol",
+				    protocol_to_string((int)obs_data_get_int(cfg, SETTING_PROTOCOL)));
+	}
+	obs_data_set_string(response_data, "source", "config");
+}
+
+static void register_vendor(void)
+{
+	if (s_vendor)
+		return;
+
+	s_vendor = obs_websocket_register_vendor(VENDOR_NAME);
+	if (!s_vendor) {
+		obs_log(LOG_INFO, "[obs-ws-vendor] obs-websocket not present; remote-control API disabled");
+		return;
+	}
+
+	if (!obs_websocket_vendor_register_request(s_vendor, REQUEST_STATUS, radio_status_request_cb, NULL)) {
+		obs_log(LOG_WARNING, "[obs-ws-vendor] failed to register '%s' request", REQUEST_STATUS);
+		return;
+	}
+
+	obs_log(LOG_INFO, "[obs-ws-vendor] registered vendor '%s' (%s)", VENDOR_NAME, REQUEST_STATUS);
+}
+
+static void on_frontend_event(enum obs_frontend_event event, void *priv)
+{
+	UNUSED_PARAMETER(priv);
+
+	/* obs-websocket is itself a module; its proc handler is only guaranteed
+	 * to be available once all modules have finished loading. */
+	if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING)
+		register_vendor();
+}
+
+void obs_ws_vendor_init(void)
+{
+	obs_frontend_add_event_callback(on_frontend_event, NULL);
+}
+
+void obs_ws_vendor_shutdown(void)
+{
+	obs_frontend_remove_event_callback(on_frontend_event, NULL);
+
+	if (s_vendor) {
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_STATUS);
+		s_vendor = NULL;
+	}
+}

--- a/src/obs-ws-vendor.h
+++ b/src/obs-ws-vendor.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+obs-radio-output
+Copyright (C) 2026 Aaron Cupp <mrcupp@mrcupp.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * obs-websocket vendor API for remote control / QA automation.
+ *
+ * Registers a vendor named "obs-radio-output" with obs-websocket so external
+ * clients (Stream Deck, scripted now-playing systems, the QA harness) can drive
+ * the plugin over the obs-websocket protocol via CallVendorRequest.
+ *
+ * Registration is deferred to OBS_FRONTEND_EVENT_FINISHED_LOADING because
+ * obs-websocket is itself a module and its proc handler is only guaranteed to be
+ * present once all modules have finished loading.  If obs-websocket is not
+ * installed, registration is a no-op and the plugin loads normally.
+ *
+ * This first increment exposes read-only verbs only:
+ *   - radio.status : current connection state + the active/configured target.
+ * Mutating verbs (radio.start/stop, radio.pushMetadata, radio.applyConfig) land
+ * in a follow-up PR with the required UI-thread marshaling.
+ */
+
+/* Call from obs_module_load().  Hooks the frontend event that performs the
+ * actual vendor registration once obs-websocket is available. */
+void obs_ws_vendor_init(void);
+
+/* Call from obs_module_unload().  Unhooks the frontend event and unregisters
+ * any requests registered with obs-websocket. */
+void obs_ws_vendor_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -20,6 +20,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-module.h>
 #include <plugin-support.h>
 #include "frontend-wire.h"
+#include "obs-ws-vendor.h"
 #include "radio-output.h"
 
 OBS_DECLARE_MODULE()
@@ -29,12 +30,14 @@ bool obs_module_load(void)
 {
 	obs_register_output(&radio_output_info);
 	frontend_wire_load();
+	obs_ws_vendor_init();
 	obs_log(LOG_INFO, "plugin loaded successfully (version %s)", PLUGIN_VERSION);
 	return true;
 }
 
 void obs_module_unload(void)
 {
+	obs_ws_vendor_shutdown();
 	frontend_wire_unload();
 	obs_log(LOG_INFO, "plugin unloaded");
 }


### PR DESCRIPTION
**Summary**

First increment of the Tier-3b obs-websocket vendor API (umbrella #91, issue #93). Registers a vendor named `obs-radio-output` with obs-websocket and exposes one **read-only** request, `radio.status`, callable via `CallVendorRequest`. This is the foundation for headless QA control (the Tier-3a harness already probes `radio.status`) and is dual-use: the same surface is what a Stream Deck / scripted now-playing integration would call.

- **No new link dependency.** Vendors obsproject's single-file `obs-websocket-api.h` (GPL-2.0, matches our license) under `deps/obs-websocket-api/`. It works via a runtime proc-handler lookup, so registration is a graceful no-op when obs-websocket is absent — the plugin loads normally either way.
- **Registration timing.** Deferred to `OBS_FRONTEND_EVENT_FINISHED_LOADING`, since obs-websocket is itself a module and its proc handler is only guaranteed present once all modules have loaded.
- **`radio.status`** reports live connection state + target when an output is running (read under `state_mutex`, mirroring the dock's `pollState()`), otherwise the saved config so a caller can see what a start would use. No side effects, answered inline on the obs-websocket thread.

**Scope notes (deliberately deferred):**
- `radio.getListeners` was planned for this PR but moved to the next one: the listener count lives only in a Qt-main-thread poller (`ListenerPoll`) with no global cache, so doing it right needs either a cached value or a synchronous HTTP client — more than an inline read verb.
- Mutating verbs (`radio.start`/`stop`/`pushMetadata`/`applyConfig`) land in `feat/obs-ws-vendor-control` with the required UI-thread marshaling (`obs_queue_task(OBS_TASK_UI, …)`).

Built locally arm64 RelWithDebInfo under the full `-Werror` set — clean, no warnings.

**Test plan**

- CI passes (clang-format, CMake format, build on macOS + Ubuntu).
- Manual verification on macOS (OBS 32.x), using the private QA harness probe `obs-ws-harness/status.mjs`:

1. **Install the rebuilt plugin:** `./build-and-install-macos.sh`
2. **Fully quit and relaunch OBS.**
3. **Confirm registration** — in OBS log (Help → Log Files → Current Log), expect:
   `[obs-ws-vendor] registered vendor 'obs-radio-output' (radio.status)`
   _Pass:_ line present. _Fail:_ absent, or a `failed to register` warning.
4. **Status while idle** (nothing streaming) —
   `OBS_WEBSOCKET_PASSWORD=… node status.mjs`
   _Expect:_ `outputActive: false`, `state: "disconnected"`, `source: "config"`, and `host`/`port`/`mount`/`codec`/`bitrate` matching the config dialog.
5. **Status while streaming** — start the radio output (dock Start, or OBS streaming with piggyback), re-run `status.mjs`.
   _Expect:_ `outputActive: true`, `state: "connected"`, `source: "active"`, `host: "localhost"`, `port: 8010`, `mount: "/stream"`, `codec: "mp3"`, `bitrate: 128`.
6. **Regression** — confirm `[obs-radio-output] plugin loaded successfully` still logs, and the dock Start/Stop + "start radio with OBS streaming" still work as before.

_Pass criteria:_ steps 3–6 all as described; no new warnings/errors in the log; no change to existing start/stop/streaming behavior.

Closes part of #93. Refs #91.
