### PR TITLE
feat(obs-ws): add radio start/stop/pushMetadata/applyConfig vendor verbs

### DIFF
--- a/src/frontend-wire.cpp
+++ b/src/frontend-wire.cpp
@@ -248,6 +248,32 @@ extern "C" bool frontend_wire_start_output(void)
 	return true;
 }
 
+extern "C" bool frontend_wire_apply_config(obs_data_t *patch)
+{
+	if (!g_config || !patch)
+		return false;
+
+	/* Copy only the keys the caller explicitly set, preserving type.  Same
+	 * TU as the anonymous-namespace helpers, so g_config / save_config_to_disk
+	 * are reachable here just as they are in frontend_wire_start_output. */
+	for (const char *key : {SETTING_HOST, SETTING_MOUNT, SETTING_PASSWORD}) {
+		if (obs_data_has_user_value(patch, key))
+			obs_data_set_string(g_config, key, obs_data_get_string(patch, key));
+	}
+	for (const char *key : {SETTING_PORT, SETTING_CODEC, SETTING_BITRATE, SETTING_PROTOCOL, SETTING_RECONNECT_DELAY,
+				SETTING_RECONNECT_MAX}) {
+		if (obs_data_has_user_value(patch, key))
+			obs_data_set_int(g_config, key, obs_data_get_int(patch, key));
+	}
+	for (const char *key : {SETTING_TLS, SETTING_RECONNECT, SETTING_START_WITH_STREAMING}) {
+		if (obs_data_has_user_value(patch, key))
+			obs_data_set_bool(g_config, key, obs_data_get_bool(patch, key));
+	}
+
+	save_config_to_disk();
+	return true;
+}
+
 extern "C" void frontend_wire_stop_output(void)
 {
 	/* Stop whichever radio output is currently live, regardless of who

--- a/src/frontend-wire.h
+++ b/src/frontend-wire.h
@@ -67,6 +67,18 @@ bool frontend_wire_start_output(void);
  */
 void frontend_wire_stop_output(void);
 
+/*
+ * Merge the recognized SETTING_* keys present in `patch` into the module
+ * config and persist it to disk.  Only keys explicitly set in `patch` are
+ * applied; everything else is left untouched.  Takes effect on the NEXT
+ * start (a running output keeps the settings it began with), matching the
+ * config dialog's behavior.
+ *
+ * MUST be called on the OBS UI thread (it mutates the UI-thread-owned config
+ * and writes to disk).  Returns false if config isn't loaded or patch is null.
+ */
+bool frontend_wire_apply_config(obs_data_t *patch);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/obs-ws-vendor.c
+++ b/src/obs-ws-vendor.c
@@ -28,14 +28,19 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <plugin-support.h>
 
 #include "frontend-wire.h"
+#include "metadata.h"
 #include "radio-output.h"
 
 /* Single-translation-unit header: defines a static proc-handler cache, so it
  * must be included in exactly one .c file (this one). */
 #include "obs-websocket-api.h"
 
-#define VENDOR_NAME      "obs-radio-output"
-#define REQUEST_STATUS   "radio.status"
+#define VENDOR_NAME         "obs-radio-output"
+#define REQUEST_STATUS      "radio.status"
+#define REQUEST_START       "radio.start"
+#define REQUEST_STOP        "radio.stop"
+#define REQUEST_METADATA    "radio.pushMetadata"
+#define REQUEST_APPLYCONFIG "radio.applyConfig"
 
 /* obs-websocket vendor handle.  NULL until OBS_FRONTEND_EVENT_FINISHED_LOADING
  * registers it, or permanently NULL if obs-websocket is not installed. */
@@ -143,6 +148,107 @@ static void radio_status_request_cb(obs_data_t *request_data, obs_data_t *respon
 	obs_data_set_string(response_data, "source", "config");
 }
 
+/*
+ * UI-thread marshaling.
+ *
+ * Vendor request callbacks fire on the obs-websocket thread, but start/stop and
+ * applyConfig touch the UI-thread-owned module state (g_active_output_handle,
+ * g_config). We hop onto the UI thread via obs_queue_task(..., wait=true) so
+ * these serialize with the dock and frontend-event paths. obs_in_task_thread()
+ * guards against the (unlikely) case of already being on the UI thread, which
+ * would deadlock a waiting queue_task.
+ */
+struct ui_start_task {
+	bool result;
+};
+static void ui_run_start(void *param)
+{
+	((struct ui_start_task *)param)->result = frontend_wire_start_output();
+}
+
+static void ui_run_stop(void *param)
+{
+	UNUSED_PARAMETER(param);
+	frontend_wire_stop_output();
+}
+
+struct ui_apply_task {
+	obs_data_t *patch;
+	bool result;
+};
+static void ui_run_apply(void *param)
+{
+	struct ui_apply_task *t = (struct ui_apply_task *)param;
+	t->result = frontend_wire_apply_config(t->patch);
+}
+
+/* radio.start — create + start the radio output (UI thread). Response: ok (bool). */
+static void radio_start_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(request_data);
+	UNUSED_PARAMETER(priv_data);
+
+	struct ui_start_task t = {false};
+	if (obs_in_task_thread(OBS_TASK_UI))
+		t.result = frontend_wire_start_output();
+	else
+		obs_queue_task(OBS_TASK_UI, ui_run_start, &t, true);
+
+	obs_data_set_bool(response_data, "ok", t.result);
+}
+
+/* radio.stop — stop the running radio output (UI thread). Idempotent. Response: ok (bool). */
+static void radio_stop_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(request_data);
+	UNUSED_PARAMETER(priv_data);
+
+	if (obs_in_task_thread(OBS_TASK_UI))
+		frontend_wire_stop_output();
+	else
+		obs_queue_task(OBS_TASK_UI, ui_run_stop, NULL, true);
+
+	obs_data_set_bool(response_data, "ok", true);
+}
+
+/*
+ * radio.pushMetadata — set the "now playing" title. radio_output_update_metadata
+ * is documented thread-safe (libshout takes its own lock), so this answers inline
+ * with no UI hop. Request: title (string). Response: ok (bool) [+ error string].
+ */
+static void radio_metadata_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(priv_data);
+
+	const char *title = obs_data_get_string(request_data, "title");
+	if (!title || !*title) {
+		obs_data_set_bool(response_data, "ok", false);
+		obs_data_set_string(response_data, "error", "missing required string field 'title'");
+		return;
+	}
+
+	obs_data_set_bool(response_data, "ok", radio_output_update_metadata(title));
+}
+
+/*
+ * radio.applyConfig — merge the provided SETTING_* keys into the saved config
+ * (UI thread). Takes effect on the next start, matching the config dialog.
+ * Request: any subset of host, port, mount, password, codec, bitrate, tls,
+ * protocol, reconnect settings, start_with_streaming. Response: ok (bool).
+ */
+static void radio_applyconfig_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(priv_data);
+
+	struct ui_apply_task t = {request_data, false};
+	if (obs_in_task_thread(OBS_TASK_UI))
+		t.result = frontend_wire_apply_config(request_data);
+	else
+		obs_queue_task(OBS_TASK_UI, ui_run_apply, &t, true);
+
+	obs_data_set_bool(response_data, "ok", t.result);
+}
+
 static void register_vendor(void)
 {
 	if (s_vendor)
@@ -154,12 +260,24 @@ static void register_vendor(void)
 		return;
 	}
 
-	if (!obs_websocket_vendor_register_request(s_vendor, REQUEST_STATUS, radio_status_request_cb, NULL)) {
-		obs_log(LOG_WARNING, "[obs-ws-vendor] failed to register '%s' request", REQUEST_STATUS);
-		return;
+	const struct {
+		const char *type;
+		obs_websocket_request_callback_function cb;
+	} requests[] = {
+		{REQUEST_STATUS, radio_status_request_cb},
+		{REQUEST_START, radio_start_request_cb},
+		{REQUEST_STOP, radio_stop_request_cb},
+		{REQUEST_METADATA, radio_metadata_request_cb},
+		{REQUEST_APPLYCONFIG, radio_applyconfig_request_cb},
+	};
+
+	for (size_t i = 0; i < sizeof(requests) / sizeof(requests[0]); i++) {
+		if (!obs_websocket_vendor_register_request(s_vendor, requests[i].type, requests[i].cb, NULL))
+			obs_log(LOG_WARNING, "[obs-ws-vendor] failed to register '%s' request", requests[i].type);
 	}
 
-	obs_log(LOG_INFO, "[obs-ws-vendor] registered vendor '%s' (%s)", VENDOR_NAME, REQUEST_STATUS);
+	obs_log(LOG_INFO, "[obs-ws-vendor] registered vendor '%s' (status, start, stop, pushMetadata, applyConfig)",
+		VENDOR_NAME);
 }
 
 static void on_frontend_event(enum obs_frontend_event event, void *priv)
@@ -183,6 +301,10 @@ void obs_ws_vendor_shutdown(void)
 
 	if (s_vendor) {
 		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_STATUS);
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_START);
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_STOP);
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_METADATA);
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_APPLYCONFIG);
 		s_vendor = NULL;
 	}
 }

--- a/src/obs-ws-vendor.h
+++ b/src/obs-ws-vendor.h
@@ -35,10 +35,18 @@ extern "C" {
  * present once all modules have finished loading.  If obs-websocket is not
  * installed, registration is a no-op and the plugin loads normally.
  *
- * This first increment exposes read-only verbs only:
- *   - radio.status : current connection state + the active/configured target.
- * Mutating verbs (radio.start/stop, radio.pushMetadata, radio.applyConfig) land
- * in a follow-up PR with the required UI-thread marshaling.
+ * Verbs:
+ *   - radio.status       : current connection state + the active/configured target (read-only)
+ *   - radio.start        : create + start the radio output
+ *   - radio.stop         : stop the running radio output (idempotent)
+ *   - radio.pushMetadata : set the "now playing" title  {title: string}
+ *   - radio.applyConfig  : merge SETTING_* keys into the saved config (next-start)
+ *
+ * radio.status and radio.pushMetadata answer inline; start/stop/applyConfig touch
+ * UI-thread-owned state and are marshaled onto the OBS UI thread.
+ *
+ * Still deferred: radio.getListeners — the count lives in a Qt-main-thread poller
+ * with no global cache; exposing it needs a cached value or a synchronous client.
  */
 
 /* Call from obs_module_load().  Hooks the frontend event that performs the


### PR DESCRIPTION
**Summary**

Second increment of the Tier-3b obs-websocket vendor API (umbrella #91, issue #93), building on #95. Adds the **mutating** verbs so external clients (and the QA harness) can drive the plugin headlessly — no dock clicks, no config dialog.

New verbs on the `obs-radio-output` vendor:
| Verb | Backs onto | Threading |
|------|-----------|-----------|
| `radio.start` | `frontend_wire_start_output` | UI-thread marshaled |
| `radio.stop` | `frontend_wire_stop_output` (idempotent) | UI-thread marshaled |
| `radio.pushMetadata` `{title}` | `radio_output_update_metadata` | inline (already thread-safe per metadata.h) |
| `radio.applyConfig` `{host,port,mount,…}` | new `frontend_wire_apply_config` | UI-thread marshaled |

**Threading.** Vendor callbacks fire on the obs-websocket thread. `start`/`stop`/`applyConfig` touch UI-thread-owned state (`g_active_output_handle`, `g_config`), so they hop onto the OBS UI thread via `obs_queue_task(OBS_TASK_UI, …, wait=true)`, serializing with the dock and frontend-event paths. `obs_in_task_thread(OBS_TASK_UI)` guards the already-on-UI-thread case to avoid a self-deadlock. `pushMetadata` answers inline because `radio_output_update_metadata` is documented thread-safe (libshout takes its own lock).

**`frontend_wire_apply_config`** merges only the `SETTING_*` keys explicitly present in the request into the saved config and persists it; takes effect on the next start, matching the config dialog. This is what makes headless codec/permutation testing possible (e.g. `applyConfig{codec:vorbis}` → `start`).

**Still deferred — `radio.getListeners`.** The count lives only in a Qt-main-thread `ListenerPoll` with no global cache; exposing it needs a cached value or a synchronous HTTP client. Tracked separately rather than bolted on here.

Built locally arm64 RelWithDebInfo under the full `-Werror` set — clean.

**Test plan**

- CI passes (clang-format, CMake format, build on macOS + Ubuntu + Windows).
- Manual verification (macOS, OBS 32.x) via the QA harness — **pending an OBS slot** (the test machine is mid-#85-Vorbis-acceptance; this will be run once that frees up):

1. Install + restart OBS; confirm `[obs-ws-vendor] registered vendor 'obs-radio-output' (status, start, stop, pushMetadata, applyConfig)` in the log.
2. `radio.applyConfig {"host":"localhost","port":8010,"mount":"/stream","codec":1,"bitrate":128}` → `{ok:true}`; verify `radio.status` (idle) reflects the new values with `source:"config"`.
3. `radio.start` → `{ok:true}`; `radio.status` → `outputActive:true`, `state:"connected"`; log shows `Connected to localhost:8010/stream`.
4. `radio.pushMetadata {"title":"Test Artist - Test Track"}` → `{ok:true}`; log shows `Now playing: Test Artist - Test Track`.
5. `radio.stop` → `{ok:true}`; `radio.status` → `outputActive:false`.
6. Regression: dock Start/Stop, "start radio with OBS streaming", and the config dialog all still behave as before.

_Pass criteria:_ steps 1–6 as described; no UI-thread stalls or new log errors.

Closes the control portion of #93. Refs #91.
