### PR TITLE
feat(obs-ws): add radio.getListeners vendor verb with dock-cached count

### DIFF
--- a/src/obs-ws-vendor.c
+++ b/src/obs-ws-vendor.c
@@ -41,6 +41,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define REQUEST_STOP        "radio.stop"
 #define REQUEST_METADATA    "radio.pushMetadata"
 #define REQUEST_APPLYCONFIG "radio.applyConfig"
+#define REQUEST_GETLISTENERS "radio.getListeners"
 
 /* obs-websocket vendor handle.  NULL until OBS_FRONTEND_EVENT_FINISHED_LOADING
  * registers it, or permanently NULL if obs-websocket is not installed. */
@@ -249,6 +250,24 @@ static void radio_applyconfig_request_cb(obs_data_t *request_data, obs_data_t *r
 	obs_data_set_bool(response_data, "ok", t.result);
 }
 
+/*
+ * radio.getListeners — read-only.  Returns the dock's last-polled listener
+ * count from the shared cache (radio_output_get_listener_count).  The cache is
+ * an atomic_int, so this needs no UI-thread marshaling.  The count may be up to
+ * one poll interval (~10 s) stale, and is -1 ("unknown") when disconnected, not
+ * yet polled, or the server stats were unparseable.
+ * Response: listeners (int), valid (bool — true when listeners >= 0).
+ */
+static void radio_getlisteners_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+{
+	UNUSED_PARAMETER(request_data);
+	UNUSED_PARAMETER(priv_data);
+
+	const int count = radio_output_get_listener_count();
+	obs_data_set_int(response_data, "listeners", count);
+	obs_data_set_bool(response_data, "valid", count >= 0);
+}
+
 static void register_vendor(void)
 {
 	if (s_vendor)
@@ -269,6 +288,7 @@ static void register_vendor(void)
 		{REQUEST_STOP, radio_stop_request_cb},
 		{REQUEST_METADATA, radio_metadata_request_cb},
 		{REQUEST_APPLYCONFIG, radio_applyconfig_request_cb},
+		{REQUEST_GETLISTENERS, radio_getlisteners_request_cb},
 	};
 
 	for (size_t i = 0; i < sizeof(requests) / sizeof(requests[0]); i++) {
@@ -276,7 +296,8 @@ static void register_vendor(void)
 			obs_log(LOG_WARNING, "[obs-ws-vendor] failed to register '%s' request", requests[i].type);
 	}
 
-	obs_log(LOG_INFO, "[obs-ws-vendor] registered vendor '%s' (status, start, stop, pushMetadata, applyConfig)",
+	obs_log(LOG_INFO,
+		"[obs-ws-vendor] registered vendor '%s' (status, start, stop, pushMetadata, applyConfig, getListeners)",
 		VENDOR_NAME);
 }
 
@@ -305,6 +326,7 @@ void obs_ws_vendor_shutdown(void)
 		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_STOP);
 		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_METADATA);
 		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_APPLYCONFIG);
+		obs_websocket_vendor_unregister_request(s_vendor, REQUEST_GETLISTENERS);
 		s_vendor = NULL;
 	}
 }

--- a/src/obs-ws-vendor.h
+++ b/src/obs-ws-vendor.h
@@ -41,12 +41,16 @@ extern "C" {
  *   - radio.stop         : stop the running radio output (idempotent)
  *   - radio.pushMetadata : set the "now playing" title  {title: string}
  *   - radio.applyConfig  : merge SETTING_* keys into the saved config (next-start)
+ *   - radio.getListeners : last-polled listener count  {listeners: int, valid: bool} (read-only)
  *
- * radio.status and radio.pushMetadata answer inline; start/stop/applyConfig touch
- * UI-thread-owned state and are marshaled onto the OBS UI thread.
+ * radio.status, radio.pushMetadata and radio.getListeners answer inline;
+ * start/stop/applyConfig touch UI-thread-owned state and are marshaled onto the
+ * OBS UI thread.
  *
- * Still deferred: radio.getListeners — the count lives in a Qt-main-thread poller
- * with no global cache; exposing it needs a cached value or a synchronous client.
+ * radio.getListeners reads a cached count the dock's ListenerPoll publishes via
+ * radio_output_set_listener_count() (atomic_int).  It is -1 ("valid": false)
+ * when disconnected / not yet polled, and may be up to one poll interval (~10 s)
+ * stale.
  */
 
 /* Call from obs_module_load().  Hooks the frontend event that performs the

--- a/src/radio-output-dock.cpp
+++ b/src/radio-output-dock.cpp
@@ -179,6 +179,11 @@ void RadioOutputDock::onListenerCount(int count)
 	/* Amber on error, default on success.  Same vocabulary the status row
 	 * uses for its RECONNECTING amber. */
 	listenerLabel_->setStyleSheet(count < 0 ? QStringLiteral("QLabel { color: #d17d00; }") : QString());
+
+	/* Publish to the shared cache the obs-websocket radio.getListeners verb
+	 * reads.  -1 (error/unknown) is forwarded verbatim so a remote client
+	 * sees the same "unknown" the dock paints amber. */
+	radio_output_set_listener_count(count);
 }
 
 void RadioOutputDock::pollState()
@@ -240,6 +245,9 @@ void RadioOutputDock::pollState()
 		listenerLabel_->setText(QString::fromUtf8(obs_module_text("RadioOutput.Dock.Listeners"))
 						.arg(obs_module_text("RadioOutput.Dock.Listeners.Unknown")));
 		listenerLabel_->setStyleSheet(QString());
+		/* No longer polling — invalidate the cached count so
+		 * radio.getListeners reports "unknown" instead of a stale value. */
+		radio_output_set_listener_count(-1);
 	}
 	lastState_ = state;
 }

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -5,6 +5,8 @@
 #include "reconnect.h"
 #include <plugin-support.h>
 
+#include <stdatomic.h>
+
 /*
  * Module-global pointer to the currently instantiated output, for the dock
  * widget (src/radio-output-dock.cpp) and frontend event handler (§B.3) to
@@ -24,6 +26,27 @@ static struct radio_output *g_active_output = NULL;
 struct radio_output *radio_output_get_active(void)
 {
 	return g_active_output;
+}
+
+/*
+ * Cached listener count for the obs-websocket radio.getListeners verb.
+ * The dock's ListenerPoll (src/radio-output-dock.cpp) is the sole writer —
+ * it stores each parsed Icecast/SHOUTcast count here (or -1 when not polling,
+ * on parse error, or when leaving CONNECTED).  The vendor request callback
+ * runs on the obs-websocket thread and reads it; an atomic_int lets that read
+ * happen without locking.  -1 means "unknown" (disconnected, not yet polled,
+ * or stats unparseable).  Value may be up to one poll interval (~10 s) stale.
+ */
+static atomic_int g_listener_count = -1;
+
+void radio_output_set_listener_count(int count)
+{
+	atomic_store(&g_listener_count, count);
+}
+
+int radio_output_get_listener_count(void)
+{
+	return atomic_load(&g_listener_count);
 }
 
 static const char *radio_output_get_name(void *type_data)

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -5,7 +5,7 @@
 #include "reconnect.h"
 #include <plugin-support.h>
 
-#include <stdatomic.h>
+#include <util/threading.h>
 
 /*
  * Module-global pointer to the currently instantiated output, for the dock
@@ -36,17 +36,22 @@ struct radio_output *radio_output_get_active(void)
  * runs on the obs-websocket thread and reads it; an atomic_int lets that read
  * happen without locking.  -1 means "unknown" (disconnected, not yet polled,
  * or stats unparseable).  Value may be up to one poll interval (~10 s) stale.
+ *
+ * Uses libobs' os_atomic_*_long rather than C11 <stdatomic.h>: MSVC only
+ * enables stdatomic under /experimental:c11atomics, which the OBS Windows
+ * build doesn't set, so stdatomic fails to compile there.  os_atomic_* is
+ * portable across MSVC/clang/gcc.
  */
-static atomic_int g_listener_count = -1;
+static volatile long g_listener_count = -1;
 
 void radio_output_set_listener_count(int count)
 {
-	atomic_store(&g_listener_count, count);
+	os_atomic_set_long(&g_listener_count, count);
 }
 
 int radio_output_get_listener_count(void)
 {
-	return atomic_load(&g_listener_count);
+	return (int)os_atomic_load_long(&g_listener_count);
 }
 
 static const char *radio_output_get_name(void *type_data)

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -168,6 +168,16 @@ extern struct obs_output_info radio_output_info;
  */
 struct radio_output *radio_output_get_active(void);
 
+/*
+ * Listener-count cache shared between the dock's ListenerPoll (writer) and the
+ * obs-websocket radio.getListeners verb (reader).  _set stores the latest
+ * parsed count, or -1 to mean "unknown" (not polling / parse error / left
+ * CONNECTED).  _get returns the last stored value.  Backed by an atomic_int in
+ * radio-output.c, so the vendor thread can read without holding any lock.
+ */
+void radio_output_set_listener_count(int count);
+int radio_output_get_listener_count(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
**Summary**

Completes the one deferred Tier 3b vendor verb (the `radio.getListeners` gap noted in #93 / PR #96). The listener count lived only in the dock's Qt-main-thread `ListenerPoll` with no cross-thread cache, so the obs-websocket callback (which runs on the obs-websocket thread) couldn't read it. This adds a tiny shared cache:

- `radio-output.c`: a `static volatile long g_listener_count` (default `-1`) with `radio_output_set_listener_count()` / `radio_output_get_listener_count()`, using libobs' `os_atomic_set_long`/`os_atomic_load_long`. Atomic so the vendor thread reads without locking; no new mutex. (Uses `os_atomic_*` rather than C11 `<stdatomic.h>` because MSVC only enables stdatomic under `/experimental:c11atomics`, which the OBS Windows build doesn't set.)
- `radio-output-dock.cpp`: `onListenerCount()` publishes every parsed count (and `-1` on poll error); the leave-CONNECTED branch invalidates the cache back to `-1`.
- `obs-ws-vendor.c`: new read-only `radio.getListeners` verb → `{listeners: int, valid: bool}`. Answers inline (atomic read, no UI marshaling). Registered/unregistered alongside the existing verbs.
- Header docs updated (`obs-ws-vendor.h` verb list; `radio-output.h` cache contract). `-1` ⇒ `valid:false` (disconnected / not yet polled / unparseable stats). Value may be up to one poll interval (~10 s) stale.

No new dependency, no link change, no-op when obs-websocket is absent (same as the other verbs).

**Test plan**
- [x] CI passes (clang-format, CMake format, build all 4 targets, 21 unit tests)
- [x] Local arm64 build + install: **BUILD SUCCEEDED**; `nm` confirms `radio_output_{set,get}_listener_count` + `g_listener_count` in the bundle; OBS log shows `registered vendor 'obs-radio-output' (… getListeners)`.
- [x] Headless verification via `obs-ws-harness/get-listeners.mjs` (icecast-qa :8010) — **5/5 assertions passed**:
  1. **disconnected** → `getListeners = -1, valid = false` ✅
  2. **connected, no listeners** (after one ~10 s poll) → `0, valid = true` ✅
  3. **2 real listeners attached** (curl holding the mount) → `2, valid = true` ✅
  4. **listeners dropped** → `0, valid = true` ✅
  5. **stopped** → `-1, valid = false` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)