### PR TITLE
ci(codeql): upgrade CodeQL Action v3 → v4

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL 🔍
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: c-cpp
           queries: security-extended
@@ -38,6 +38,6 @@ jobs:
           config: RelWithDebInfo
 
       - name: Perform CodeQL Analysis 🔍
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
Closes #45. Bumps `github/codeql-action/init` and `/analyze` from `@v3` to `@v4` (latest v4.36.2). v3 runners are being deprecated. No config changes — CodeQL scan on this PR is the verification.