### PR TITLE
ci(ubuntu): add Linux aarch64 build target

### DIFF
--- a/.github/scripts/build-ubuntu
+++ b/.github/scripts/build-ubuntu
@@ -54,6 +54,7 @@ build() {
   local -r _version='2.0.0'
   local -r -a _valid_targets=(
     ubuntu-x86_64
+    ubuntu-aarch64
   )
   local target
   local config='RelWithDebInfo'

--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -53,6 +53,7 @@ package() {
   local -r _version='2.0.0'
   local -r -a _valid_targets=(
     ubuntu-x86_64
+    ubuntu-aarch64
   )
   local target
   local config='RelWithDebInfo'

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -206,8 +206,13 @@ jobs:
   ubuntu-build:
     name: Build for Ubuntu 🐧
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        include:
+          - os: ubuntu-24.04
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     runs-on: ${{ matrix.os }}
     needs: check-event
     defaults:
@@ -252,27 +257,27 @@ jobs:
         id: ccache-cache
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
+          key: ${{ runner.os }}-${{ matrix.os }}-ccache-${{ matrix.arch }}-${{ needs.check-event.outputs.config }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-
+            ${{ runner.os }}-${{ matrix.os }}-ccache-${{ matrix.arch }}-
 
       - name: Build Plugin 🧱
         uses: ./.github/actions/build-plugin
         with:
-          target: x86_64
+          target: ${{ matrix.arch }}
           config: ${{ needs.check-event.outputs.config }}
 
       - name: Run Unit Tests 🧪
         shell: bash
         run: |
           : Run Unit Tests 🧪
-          cmake --build build_x86_64 --config ${{ needs.check-event.outputs.config }} --target radio-tests
-          ctest --test-dir build_x86_64 --build-config ${{ needs.check-event.outputs.config }} --output-on-failure
+          cmake --build build_${{ matrix.arch }} --config ${{ needs.check-event.outputs.config }} --target radio-tests
+          ctest --test-dir build_${{ matrix.arch }} --build-config ${{ needs.check-event.outputs.config }} --output-on-failure
 
       - name: Package Plugin 📀
         uses: ./.github/actions/package-plugin
         with:
-          target: x86_64
+          target: ${{ matrix.arch }}
           config: ${{ needs.check-event.outputs.config }}
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
 
@@ -285,21 +290,21 @@ jobs:
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*.*
+          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-${{ matrix.arch }}-${{ needs.check-event.outputs.commitHash }}
+          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.arch }}*.*
 
       - name: Upload debug symbol artifacts 🪲
         uses: actions/upload-artifact@v4
         if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}-dbgsym
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*-dbgsym.ddeb
+          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-${{ matrix.arch }}-${{ needs.check-event.outputs.commitHash }}-dbgsym
+          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.arch }}*-dbgsym.ddeb
 
       - uses: actions/cache/save@v4
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
+          key: ${{ runner.os }}-${{ matrix.os }}-ccache-${{ matrix.arch }}-${{ needs.check-event.outputs.config }}
 
   windows-build:
     name: Build for Windows 🪟

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,6 +100,36 @@
         "ENABLE_CCACHE": true,
         "ENABLE_TESTING": true
       }
+    },
+    {
+      "name": "ubuntu-aarch64",
+      "displayName": "Ubuntu aarch64",
+      "description": "Build for Ubuntu aarch64",
+      "inherits": ["template"],
+      "binaryDir": "${sourceDir}/build_aarch64",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "generator": "Ninja",
+      "warnings": {"dev": true, "deprecated": true},
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_INSTALL_LIBDIR": "lib/CMAKE_SYSTEM_PROCESSOR-linux-gnu"
+      }
+    },
+    {
+      "name": "ubuntu-ci-aarch64",
+      "inherits": ["ubuntu-aarch64"],
+      "displayName": "Ubuntu aarch64 CI build",
+      "description": "Build for Ubuntu aarch64 on CI",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "ENABLE_CCACHE": true,
+        "ENABLE_TESTING": true
+      }
     }
   ],
   "buildPresets": [
@@ -143,6 +173,20 @@
       "configurePreset": "ubuntu-ci-x86_64",
       "displayName": "Ubuntu x86_64 CI",
       "description": "Ubuntu CI build for x86_64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-aarch64",
+      "configurePreset": "ubuntu-aarch64",
+      "displayName": "Ubuntu aarch64",
+      "description": "Ubuntu build for aarch64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-ci-aarch64",
+      "configurePreset": "ubuntu-ci-aarch64",
+      "displayName": "Ubuntu aarch64 CI",
+      "description": "Ubuntu CI build for aarch64",
       "configuration": "RelWithDebInfo"
     }
   ]


### PR DESCRIPTION
Closes #38. Adds a native `ubuntu-24.04-arm` build alongside x86_64 — free runner for public repos, apt deps are arch-agnostic.

## Changes
- **build-project.yaml** — `ubuntu-build` now an include-matrix of `{ubuntu-24.04, x86_64}` + `{ubuntu-24.04-arm, aarch64}`; every hardcoded `x86_64` (build/package target, ccache key, build dir, artifact name/path) parameterized to `${{ matrix.arch }}`. `fail-fast: false` so one arch failing doesn't cancel the other. MinGW Windows lines untouched.
- **CMakePresets.json** — added `ubuntu-aarch64` + `ubuntu-ci-aarch64` (configure + build), cloned from the x86_64 pair.
- **build-ubuntu / package-ubuntu** — `ubuntu-aarch64` added to each `_valid_targets`.

## Verification
CI is the test: the new **Build for Ubuntu 🐧 (aarch64)** job must compile + pass the 21 unit tests on arm64. The x86_64 job must stay green.

## Known follow-up
The artifact glob is `-aarch64*`; if cpack names the `.deb` with Debian's `arm64`, the upload will warn (not fail) and needs a one-line tweak. Build + unit-test pass is the #38 acceptance signal.