### PR TITLE
feat(metadata): in-band Now Playing for Opus/Vorbis via Ogg chaining

### DIFF
--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "metadata.h"
+#include "radio-encoder.h"
 #include "radio-output.h"
 
 #include <plugin-support.h>
@@ -88,5 +89,13 @@ bool radio_output_update_metadata(const char *title)
 	struct radio_output *active = radio_output_get_active();
 	if (!active)
 		return false;
+
+	/* Container codecs (Opus/Vorbis) expose an update_metadata hook: Icecast
+	 * discards admin/ICY metadata on Ogg mounts, so the title is spliced into
+	 * the stream in-band instead (#67).  MP3 has no such hook and falls through
+	 * to the libshout ICY/admin path, which works for it. */
+	if (active->encoder && active->encoder->update_metadata)
+		return radio_output_emit_inband_metadata(active, title);
+
 	return metadata_update(active, title) == 0;
 }

--- a/src/ogg-opus-headers.c
+++ b/src/ogg-opus-headers.c
@@ -2,7 +2,17 @@
 
 #include "ogg-opus-headers.h"
 
+#include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
+
+static void put_le32(uint8_t *p, uint32_t v)
+{
+	p[0] = (uint8_t)(v & 0xFF);
+	p[1] = (uint8_t)((v >> 8) & 0xFF);
+	p[2] = (uint8_t)((v >> 16) & 0xFF);
+	p[3] = (uint8_t)((v >> 24) & 0xFF);
+}
 
 void opus_format_head(uint8_t out[OPUS_HEAD_SIZE], uint8_t channels, uint16_t pre_skip, uint32_t input_sample_rate)
 {
@@ -22,24 +32,44 @@ void opus_format_head(uint8_t out[OPUS_HEAD_SIZE], uint8_t channels, uint16_t pr
 
 size_t opus_format_tags(uint8_t *out, size_t cap, const char *vendor)
 {
+	return opus_format_tags_titled(out, cap, vendor, NULL);
+}
+
+size_t opus_format_tags_titled(uint8_t *out, size_t cap, const char *vendor, const char *title)
+{
 	const size_t vendor_len = strlen(vendor);
-	const size_t total = 8 + 4 + vendor_len + 4;
+
+	/* Build the optional "TITLE=<title>" user comment, truncated. */
+	char comment[6 + OPUS_TAGS_TITLE_MAX + 1]; /* "TITLE=" + title + NUL */
+	size_t comment_len = 0;
+	const bool has_title = (title && *title);
+	if (has_title) {
+		int n = snprintf(comment, sizeof(comment), "TITLE=%.*s", OPUS_TAGS_TITLE_MAX, title);
+		if (n < 0)
+			return 0;
+		comment_len = ((size_t)n < sizeof(comment)) ? (size_t)n : sizeof(comment) - 1;
+	}
+
+	const uint32_t ncomments = has_title ? 1u : 0u;
+	const size_t total = 8 + 4 + vendor_len + 4 + (has_title ? 4 + comment_len : 0);
 	if (cap < total)
 		return 0;
 
-	memcpy(out, "OpusTags", 8);
-	const uint32_t vlen = (uint32_t)vendor_len;
-	out[8] = (uint8_t)(vlen & 0xFF);
-	out[9] = (uint8_t)((vlen >> 8) & 0xFF);
-	out[10] = (uint8_t)((vlen >> 16) & 0xFF);
-	out[11] = (uint8_t)((vlen >> 24) & 0xFF);
-	memcpy(out + 12, vendor, vendor_len);
-
-	/* user_comment_list_length = 0 (no per-comment data follows) */
-	out[12 + vendor_len + 0] = 0;
-	out[12 + vendor_len + 1] = 0;
-	out[12 + vendor_len + 2] = 0;
-	out[12 + vendor_len + 3] = 0;
+	size_t p = 0;
+	memcpy(out + p, "OpusTags", 8);
+	p += 8;
+	put_le32(out + p, (uint32_t)vendor_len);
+	p += 4;
+	memcpy(out + p, vendor, vendor_len);
+	p += vendor_len;
+	put_le32(out + p, ncomments);
+	p += 4;
+	if (has_title) {
+		put_le32(out + p, (uint32_t)comment_len);
+		p += 4;
+		memcpy(out + p, comment, comment_len);
+		p += comment_len;
+	}
 
 	return total;
 }

--- a/src/ogg-opus-headers.h
+++ b/src/ogg-opus-headers.h
@@ -32,6 +32,16 @@ void opus_format_head(uint8_t out[OPUS_HEAD_SIZE], uint8_t channels, uint16_t pr
  */
 size_t opus_format_tags(uint8_t *out, size_t cap, const char *vendor);
 
+/*
+ * Like opus_format_tags() but carrying one optional "TITLE=<title>" user comment
+ * (VorbisComment) for in-band "Now Playing" metadata (issue #67).  A NULL or
+ * empty title emits zero user comments — byte-identical to opus_format_tags().
+ * The title is truncated to OPUS_TAGS_TITLE_MAX bytes to bound the packet size.
+ * Returns the number of bytes written, or 0 if cap is too small.
+ */
+#define OPUS_TAGS_TITLE_MAX 255
+size_t opus_format_tags_titled(uint8_t *out, size_t cap, const char *vendor, const char *title);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/radio-encoder.h
+++ b/src/radio-encoder.h
@@ -97,6 +97,25 @@ struct radio_encoder_ops {
 	 * scratch buffer.  Must account for any pending internal buffering.
 	 */
 	size_t (*max_output_for)(struct radio_output *context, size_t frames);
+
+	/*
+	 * Optional (may be NULL).  In-band "Now Playing" metadata for container
+	 * codecs (issue #67).  Icecast discards admin/ICY metadata on Ogg mounts,
+	 * so Ogg codecs instead splice a new logical bitstream into the live
+	 * stream: end the current Ogg stream, start a fresh one (new serial) whose
+	 * OpusTags / VorbisComment carries the new title, and continue encoding
+	 * into it.  The encoder writes those chain bytes into a freshly bmalloc'd
+	 * buffer returned via out_bytes/out_len (caller frees with bfree) — same
+	 * ownership contract as init()/on_reconnect().  The compression context is
+	 * preserved where the codec allows (Opus keeps its OpusEncoder; Vorbis must
+	 * fully re-init because audio packets reference the header codebook).
+	 *
+	 * Called by radio_output_emit_inband_metadata under encoder_mutex (so it
+	 * can't race the audio thread's encode_frame), and only while CONNECTED.
+	 * Encoders that have no in-band metadata (MP3 — uses the libshout ICY/admin
+	 * path) leave this NULL.  Returns 0 on success, -1 on error.
+	 */
+	int (*update_metadata)(struct radio_output *context, const char *title, uint8_t **out_bytes, size_t *out_len);
 };
 
 extern const struct radio_encoder_ops radio_encoder_mp3;

--- a/src/radio-opus-encoder.c
+++ b/src/radio-opus-encoder.c
@@ -74,6 +74,11 @@ struct opus_state {
 	/* Reconnect counter — xor'd into the Ogg serial on each reset so
 	 * back-to-back reconnects never collide on the same serial. */
 	unsigned int reconnect_epoch;
+
+	/* Current "Now Playing" title, emitted in OpusTags.  Empty until the
+	 * first metadata push; re-emitted on every container reset (reconnect or
+	 * metadata update) so a rejoining listener sees the live title (#67). */
+	char title[OPUS_TAGS_TITLE_MAX + 1];
 };
 
 /*
@@ -193,8 +198,9 @@ static bool emit_opus_container_headers(struct opus_state *st, uint8_t **out_hea
 	 * stack buffer is ample.  libogg copies the packet bytes in
 	 * ogg_stream_packetin, so the buffer needn't outlive this call.  Byte
 	 * layout lives in ogg-opus-headers.c. */
-	uint8_t tags[64];
-	const size_t tags_len = opus_format_tags(tags, sizeof(tags), "obs-radio-output");
+	/* Sized for the vendor string plus one full-length TITLE comment. */
+	uint8_t tags[8 + 4 + 16 + 4 + 4 + OPUS_TAGS_TITLE_MAX + 16];
+	const size_t tags_len = opus_format_tags_titled(tags, sizeof(tags), "obs-radio-output", st->title);
 
 	ogg_packet op_tags = {0};
 	op_tags.packet = tags;
@@ -300,26 +306,19 @@ static bool opus_init(struct radio_output *context, uint32_t sample_rate, int ch
 	return true;
 }
 
-static int opus_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+/*
+ * Start a fresh Ogg logical stream (new serial) and emit OpusHead + OpusTags
+ * into out_headers/out_bytes — the chaining primitive shared by reconnect and
+ * in-band metadata.  The OpusEncoder and the PCM accumulator are intentionally
+ * preserved (only the container is reset): perceptual state stays valid and any
+ * partial frame in st->accum continues into the new stream.  packetno/granulepos
+ * restart at 0, so a listener joining the new stream begins at gp=0.
+ */
+static int opus_restart_logical_stream(struct opus_state *st, uint8_t **out_headers, size_t *out_bytes)
 {
-	struct opus_state *st = context->encoder_priv;
 	*out_headers = NULL;
 	*out_bytes = 0;
 
-	if (!st) {
-		obs_log(LOG_ERROR, "[opus] on_reconnect called without encoder state");
-		return -1;
-	}
-
-	/* Reset the Ogg container.  Icecast treats the new source connection
-	 * as a fresh stream, so listeners need a BOS page with OpusHead before
-	 * they can decode.  A new serial is required — a logical stream
-	 * continues across pages only if its serial matches.
-	 *
-	 * The OpusEncoder itself (and the PCM accumulator) are intentionally
-	 * preserved: perceptual state like the pitch predictor and LPC
-	 * residuals is still valid across the TCP blip, and whatever partial
-	 * frame was in st->accum would otherwise be lost. */
 	if (st->os_initialized) {
 		ogg_stream_clear(&st->os);
 		st->os_initialized = false;
@@ -331,19 +330,58 @@ static int opus_on_reconnect(struct radio_output *context, uint8_t **out_headers
 	ogg_stream_init(&st->os, (int)serial);
 	st->os_initialized = true;
 
-	/* Restart the packet and granule counters for the new logical stream.
-	 * A listener joining this new stream has no idea the previous one
-	 * existed; from their POV playback begins at gp=0. */
 	st->packetno = 0;
 	st->granulepos = 0;
 
-	if (!emit_opus_container_headers(st, out_headers, out_bytes)) {
+	if (!emit_opus_container_headers(st, out_headers, out_bytes))
+		return -1;
+	return 0;
+}
+
+static int opus_on_reconnect(struct radio_output *context, uint8_t **out_headers, size_t *out_bytes)
+{
+	struct opus_state *st = context->encoder_priv;
+	*out_headers = NULL;
+	*out_bytes = 0;
+
+	if (!st) {
+		obs_log(LOG_ERROR, "[opus] on_reconnect called without encoder state");
+		return -1;
+	}
+
+	/* Icecast treats the new source connection as a fresh stream, so
+	 * listeners need a BOS page with OpusHead before they can decode. */
+	if (opus_restart_logical_stream(st, out_headers, out_bytes) != 0) {
 		obs_log(LOG_ERROR, "[opus] failed to re-emit container headers on reconnect");
 		return -1;
 	}
 
-	obs_log(LOG_INFO, "[opus] re-emitted Ogg container headers after reconnect (%zu bytes, serial 0x%08x)",
-		*out_bytes, (unsigned int)serial);
+	obs_log(LOG_INFO, "[opus] re-emitted Ogg container headers after reconnect (%zu bytes)", *out_bytes);
+	return 0;
+}
+
+static int opus_update_metadata(struct radio_output *context, const char *title, uint8_t **out_bytes, size_t *out_len)
+{
+	struct opus_state *st = context->encoder_priv;
+	*out_bytes = NULL;
+	*out_len = 0;
+
+	if (!st) {
+		obs_log(LOG_ERROR, "[opus] update_metadata called without encoder state");
+		return -1;
+	}
+
+	/* Stash the title so it survives a later reconnect's header re-emit, then
+	 * chain a new logical stream whose OpusTags carries it. */
+	snprintf(st->title, sizeof(st->title), "%s", title ? title : "");
+
+	if (opus_restart_logical_stream(st, out_bytes, out_len) != 0) {
+		obs_log(LOG_ERROR, "[opus] failed to chain new stream for metadata update");
+		return -1;
+	}
+
+	obs_log(LOG_INFO, "[opus] in-band metadata: chained new Ogg stream with updated OpusTags (%zu bytes)",
+		*out_len);
 	return 0;
 }
 
@@ -462,6 +500,7 @@ const struct radio_encoder_ops radio_encoder_opus = {
 	.flush = opus_flush,
 	.max_output_for = opus_max_output_for,
 	.on_reconnect = opus_on_reconnect,
+	.update_metadata = opus_update_metadata,
 };
 
 #else /* !HAVE_OPUS — stub so the plugin still links when libopus is absent */

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -388,6 +388,52 @@ static void send_buf_push(struct radio_output *context, const uint8_t *bytes, si
 }
 #endif /* HAVE_LIBSHOUT */
 
+/*
+ * In-band "Now Playing" metadata for container codecs (Opus/Vorbis, #67).
+ * Icecast discards admin/ICY metadata on Ogg mounts, so the encoder chains a
+ * new Ogg logical stream whose OpusTags / VorbisComment carries the title; we
+ * ship those bytes through the ring buffer so they interleave with the audio.
+ *
+ * Runs under encoder_mutex — the same lock encode_frame trylocks — so the
+ * container reset can't race an in-flight audio encode.  Acts only while
+ * CONNECTED.  Returns false (no-op) when the active codec has no in-band path
+ * (MP3) or we're not streaming; the caller then uses the libshout path.
+ */
+bool radio_output_emit_inband_metadata(struct radio_output *context, const char *title)
+{
+#ifndef HAVE_LIBSHOUT
+	UNUSED_PARAMETER(context);
+	UNUSED_PARAMETER(title);
+	return false;
+#else
+	if (!context || !context->encoder || !context->encoder->update_metadata)
+		return false;
+
+	pthread_mutex_lock(&context->state_mutex);
+	bool connected = (context->state == RADIO_STATE_CONNECTED);
+	pthread_mutex_unlock(&context->state_mutex);
+	if (!connected) {
+		obs_log(LOG_WARNING, "metadata update failed: not connected");
+		return false;
+	}
+
+	uint8_t *bytes = NULL;
+	size_t len = 0;
+	pthread_mutex_lock(&context->encoder_mutex);
+	int rc = context->encoder->update_metadata(context, title, &bytes, &len);
+	pthread_mutex_unlock(&context->encoder_mutex);
+
+	if (rc != 0) {
+		bfree(bytes);
+		return false;
+	}
+	if (bytes && len)
+		send_buf_push(context, bytes, len);
+	bfree(bytes);
+	return true;
+#endif
+}
+
 /* -------------------------------------------------------------------------
  * MP3 encoder vtable (libmp3lame)
  *

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -224,6 +224,15 @@ struct radio_output *radio_output_get_active(void);
 void radio_output_set_listener_count(int count);
 int radio_output_get_listener_count(void);
 
+/*
+ * Emit in-band "Now Playing" metadata for container codecs (Opus/Vorbis, #67).
+ * Returns true if the active encoder has an in-band metadata path and accepted
+ * the title; false otherwise (the caller then falls back to the libshout
+ * ICY/admin metadata path used for MP3).  Defined in radio-output.c so it can
+ * reach the static send buffer and encoder_mutex.
+ */
+bool radio_output_emit_inband_metadata(struct radio_output *context, const char *title);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/radio-vorbis-encoder.c
+++ b/src/radio-vorbis-encoder.c
@@ -72,6 +72,11 @@ struct vorbis_state {
 	/* Bumped on every reconnect and folded into the Ogg serial so
 	 * back-to-back reconnects never reuse a serial. */
 	unsigned int reconnect_epoch;
+
+	/* Current "Now Playing" title, emitted as a TITLE VorbisComment.  Empty
+	 * until the first metadata push; re-emitted on every header rebuild
+	 * (reconnect or metadata update) so rejoining listeners see it (#67). */
+	char title[256];
 };
 
 /*
@@ -173,6 +178,8 @@ static bool vorbis_setup_and_emit_headers(struct vorbis_state *st, int bitrate, 
 	vorbis_comment_init(&st->vc);
 	st->vc_initialized = true;
 	vorbis_comment_add_tag(&st->vc, "ENCODER", "obs-radio-output");
+	if (st->title[0])
+		vorbis_comment_add_tag(&st->vc, "TITLE", st->title);
 
 	if (vorbis_analysis_init(&st->vd, &st->vi) != 0) {
 		obs_log(LOG_ERROR, "vorbis_analysis_init failed");
@@ -331,6 +338,36 @@ static int vorbis_on_reconnect(struct radio_output *context, uint8_t **out_heade
 	return 0;
 }
 
+static int vorbis_update_metadata(struct radio_output *context, const char *title, uint8_t **out_bytes, size_t *out_len)
+{
+	struct vorbis_state *st = context->encoder_priv;
+	*out_bytes = NULL;
+	*out_len = 0;
+
+	if (!st) {
+		obs_log(LOG_ERROR, "[vorbis] update_metadata called without encoder state");
+		return -1;
+	}
+
+	/* Stash the title (re-emitted on later reconnects too), then chain a fresh
+	 * logical stream whose VorbisComment carries it.  Vorbis must fully rebuild
+	 * — audio packets reference the header codebook — so this is the same path
+	 * as on_reconnect, only triggered by a title change. */
+	snprintf(st->title, sizeof(st->title), "%s", title ? title : "");
+
+	vorbis_clear_state(st);
+	st->reconnect_epoch++;
+
+	if (!vorbis_setup_and_emit_headers(st, context->bitrate, out_bytes, out_len)) {
+		obs_log(LOG_ERROR, "[vorbis] failed to chain new stream for metadata update");
+		return -1;
+	}
+
+	obs_log(LOG_INFO, "[vorbis] in-band metadata: chained new Ogg stream with updated VorbisComment (%zu bytes)",
+		*out_len);
+	return 0;
+}
+
 static void vorbis_destroy(struct radio_output *context)
 {
 	struct vorbis_state *st = context->encoder_priv;
@@ -425,6 +462,7 @@ const struct radio_encoder_ops radio_encoder_vorbis = {
 	.flush = vorbis_flush,
 	.max_output_for = vorbis_max_output_for,
 	.on_reconnect = vorbis_on_reconnect,
+	.update_metadata = vorbis_update_metadata,
 };
 
 #else /* !HAVE_VORBIS — stub so the plugin still links when libvorbis is absent */

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -65,10 +65,18 @@ const char *shout_get_error(shout_t *self)
 }
 
 // metadata.c also defines radio_output_update_metadata(), which references
-// this; never called from the tests but must resolve at link time.
+// these two; never called from the tests (radio_output_get_active returns
+// nullptr) but must resolve at link time.
 struct radio_output *radio_output_get_active(void)
 {
 	return nullptr;
+}
+
+bool radio_output_emit_inband_metadata(struct radio_output *context, const char *title)
+{
+	(void)context;
+	(void)title;
+	return false;
 }
 }
 

--- a/tests/test_opus_headers.cpp
+++ b/tests/test_opus_headers.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 extern "C" {
 #include "ogg-opus-headers.h"
@@ -81,4 +82,44 @@ TEST_CASE("OpusTags reports 0 when the buffer is too small", "[opus][headers]")
 {
 	uint8_t tiny[4];
 	REQUIRE(opus_format_tags(tiny, sizeof(tiny), "obs-radio-output") == 0);
+}
+
+TEST_CASE("OpusTags titled is byte-identical to untitled for empty/NULL title", "[opus][headers]")
+{
+	const char *vendor = "obs-radio-output";
+	uint8_t a[64];
+	uint8_t b[64];
+	const size_t na = opus_format_tags(a, sizeof(a), vendor);
+	const size_t nb = opus_format_tags_titled(b, sizeof(b), vendor, "");
+	const size_t nc = opus_format_tags_titled(a, sizeof(a), vendor, nullptr);
+	REQUIRE(na == nb);
+	REQUIRE(nb == nc);
+	REQUIRE(std::memcmp(a, b, na) == 0);
+}
+
+TEST_CASE("OpusTags titled carries one TITLE comment (issue #67)", "[opus][headers]")
+{
+	const char *vendor = "obs-radio-output";
+	const size_t vendor_len = std::strlen(vendor);
+	const char *title = "Artist - Song";
+	const std::string comment = std::string("TITLE=") + title;
+
+	uint8_t tags[128];
+	const size_t n = opus_format_tags_titled(tags, sizeof(tags), vendor, title);
+
+	REQUIRE(n == 8 + 4 + vendor_len + 4 + 4 + comment.size());
+	REQUIRE(std::memcmp(tags, "OpusTags", 8) == 0);
+	REQUIRE(le32(tags + 8) == static_cast<uint32_t>(vendor_len));
+	// one user comment follows the vendor string
+	const size_t list_off = 12 + vendor_len;
+	REQUIRE(le32(tags + list_off) == 1u);
+	REQUIRE(le32(tags + list_off + 4) == static_cast<uint32_t>(comment.size()));
+	REQUIRE(std::memcmp(tags + list_off + 8, comment.data(), comment.size()) == 0);
+}
+
+TEST_CASE("OpusTags titled reports 0 when the buffer is too small for the comment", "[opus][headers]")
+{
+	// Enough for vendor + zero comments, but not the TITLE comment.
+	uint8_t buf[8 + 4 + 16 + 4];
+	REQUIRE(opus_format_tags_titled(buf, sizeof(buf), "obs-radio-output", "a long enough title") == 0);
 }


### PR DESCRIPTION
Closes #67.

## What
Icecast silently discards admin/ICY metadata on **Ogg mounts**, so today a "Now Playing" push on Opus/Vorbis updates nothing for listeners (the plugin logs success but the title never reaches them). This adds **in-band** metadata for container codecs: on a title push the encoder chains a new Ogg logical stream whose `OpusTags` / `VorbisComment` carries the title, and continues encoding into it. MP3 is unchanged — it keeps the working libshout ICY/admin path.

## How
- New **optional** `update_metadata` hook on `struct radio_encoder_ops` (NULL for MP3).
- It reuses the proven `on_reconnect` chaining primitive (PR #58/#85): reset the Ogg stream → new serial → re-emit headers with the new tags. Opus keeps its `OpusEncoder` (only the container resets); Vorbis fully re-inits (audio packets reference the header codebook).
- The title is **stashed on the encoder** so a later reconnect re-emits it too — a listener who joins after a reconnect still sees the current title.
- `opus_format_tags_titled()` adds one optional `TITLE=` VorbisComment; `opus_format_tags()` is now a thin wrapper (existing bytes unchanged).
- Dispatch in `radio_output_update_metadata`: Ogg codec → `radio_output_emit_inband_metadata` (holds `encoder_mutex` so it can't race the audio thread; ships bytes through the ring buffer); MP3 → existing `shout_set_metadata_utf8`.

## Tradeoff (by design, accepted)
Each Ogg title change is a chain boundary; a few players re-buffer briefly there. Metadata is per-song (event-driven, not periodic), so this is a sub-second blip every few minutes on Ogg only. MP3 listeners are unaffected.

## Verified locally
- Plugin builds clean (arm64).
- Unit tests: `test_opus_headers` **31 assertions / 8 cases PASS**, including 4 new cases for `opus_format_tags_titled` (empty/NULL == untitled; one TITLE comment byte-layout; too-small-buffer).

## Manual test plan (your gate — needs a real Ogg listener)
1. **Opus in-band** — stream Opus to Icecast, play `http://localhost:8000/stream` in VLC. Push `Artist - Song` from the dock. **Expect:** log `[opus] in-band metadata: chained new Ogg stream with updated OpusTags`; VLC's now-playing title updates to `Artist - Song` within a few seconds. (`ffprobe` the mount → `TITLE` tag present.)
2. **Vorbis in-band** — same with Codec = Vorbis. **Expect:** log `[vorbis] in-band metadata: chained new Ogg stream with updated VorbisComment`; VLC title updates.
3. **MP3 regression** — Codec = MP3, push a title. **Expect:** unchanged behavior — `Now playing:` via the libshout path, Icecast admin `/status-json.xsl` reflects it; no `chained new Ogg stream` log.
4. **Title survives reconnect** — on Opus, push a title, then `docker restart icecast`. **Expect:** after reconnect, a listener opening the stream fresh sees the **current** title (headers re-emitted with it), not a blank.
5. **Not connected** — push a title while stopped. **Expect:** graceful `metadata update failed: not connected`, no crash.
6. **Audio continuity** — confirm the per-update chain boundary is at most a brief blip in VLC (no sustained dropout).