### PR TITLE
fix(connect): run shout_open on a detached connect thread to keep the UI responsive

### DIFF
--- a/src/obs-ws-vendor.c
+++ b/src/obs-ws-vendor.c
@@ -183,7 +183,10 @@ static void ui_run_apply(void *param)
 	t->result = frontend_wire_apply_config(t->patch);
 }
 
-/* radio.start — create + start the radio output (UI thread). Response: ok (bool). */
+/* radio.start — create + start the radio output (UI thread). Response: ok (bool).
+ * ok=true means the start was initiated; the connection itself completes
+ * asynchronously on a connect thread (#61) — poll radio.status for
+ * connecting → connected|error. */
 static void radio_start_request_cb(obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
 {
 	UNUSED_PARAMETER(request_data);

--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -107,6 +107,10 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 	return context;
 }
 
+#ifdef HAVE_LIBSHOUT
+static void connect_cancel(struct radio_output *context);
+#endif
+
 /*
  * radio_output_teardown — idempotent teardown used by both the stop and
  * destroy callbacks.  Must be called before freeing the context itself.
@@ -131,6 +135,13 @@ static void radio_output_teardown(struct radio_output *context)
 		return;
 	}
 	pthread_mutex_unlock(&context->state_mutex);
+
+#ifdef HAVE_LIBSHOUT
+	/* Cancel any in-flight async connect FIRST so the connect thread can't
+	 * complete a start underneath this teardown.  Returns immediately —
+	 * never waits out a blocked shout_open (#61). */
+	connect_cancel(context);
+#endif
 
 	/* Stop the audio callback BEFORE freeing anything it touches. */
 	obs_output_end_data_capture(context->output);
@@ -385,6 +396,234 @@ static void send_buf_push(struct radio_output *context, const uint8_t *bytes, si
 		obs_log(LOG_WARNING, "send buffer full, dropped %zu bytes", dropped);
 	pthread_cond_signal(&context->send_cond);
 	pthread_mutex_unlock(&context->send_mutex);
+}
+
+/* -------------------------------------------------------------------------
+ * Async initial connect (#61)
+ *
+ * shout_open blocks — DNS, TCP connect, the libshout greeting, and (with TLS
+ * on) the full TLS handshake all run inside it; ~14 s observed against a
+ * server that silently eats the ClientHello.  radio_output_start runs on the
+ * Qt main thread (dock Start, Tools menu, the streaming auto-start handler,
+ * and the obs-websocket radio.start verb all marshal to it), so the open
+ * happens on a short-lived detached connect thread instead: start returns
+ * immediately with state CONNECTING and the thread finishes the start —
+ * publish the handle, begin data capture, stand up the send thread — when
+ * shout_open returns.  Failures surface via
+ * obs_output_signal_stop(OBS_OUTPUT_CONNECT_FAILED), the same channel the
+ * reconnect give-up path already uses.
+ *
+ * Cancellation: shout_open cannot be interrupted, so Stop must never wait
+ * for it.  The job below is refcounted — the connect thread and
+ * context->connect_job each hold one ref.  Teardown atomically takes the
+ * context's pointer (under state_mutex), flags the job canceled (under
+ * job->mutex), and moves on; the blocked open finishes in the background and
+ * hands an opened handle to shout_handoff_cleanup.  A canceled thread never
+ * touches the context again, so destroy can free it safely.  Conversely,
+ * while the thread holds job->mutex with canceled still false, teardown is
+ * blocked at the flag-set, which keeps the context alive for the entire
+ * completion.
+ * ---------------------------------------------------------------------- */
+
+struct radio_connect_job {
+	struct radio_output *context; /* read only while !canceled under mutex */
+	shout_t *shout;               /* configured + unopened at spawn; thread-owned */
+	uint8_t *startup_bytes;       /* container startup pages (Ogg headers); job-owned */
+	size_t startup_len;
+	pthread_mutex_t mutex; /* guards canceled/completed; serializes completion vs cancel */
+	bool canceled;
+	bool completed;
+	volatile long refs;
+};
+
+static void connect_job_release(struct radio_connect_job *job)
+{
+	if (os_atomic_dec_long(&job->refs) > 0)
+		return;
+	pthread_mutex_destroy(&job->mutex);
+	bfree(job);
+}
+
+static void log_shout_open_failure(struct radio_output *context, shout_t *shout, int err)
+{
+	/* Surface TLS-specific failures with actionable text rather than
+	 * libshout's generic error string, which often reads as an
+	 * opaque socket/TLS mashup.  SHOUTERR_NOTLS fires only when the
+	 * server cleanly signals "no TLS" via an HTTP response; plain
+	 * servers that silently eat a TLS ClientHello yield
+	 * SHOUTERR_SOCKET after a ~14s TLS handshake timeout, so when
+	 * use_tls is on and we hit any non-TLS-specific failure, add
+	 * a TLS-may-be-the-cause hint so the user knows what to try. */
+	if (err == SHOUTERR_NOTLS) {
+		obs_log(LOG_ERROR, "TLS requested but the server does not support it; "
+				   "either disable TLS in Tools → Radio Output… or use a TLS-capable server");
+	} else if (err == SHOUTERR_TLSBADCERT) {
+		obs_log(LOG_ERROR, "TLS certificate validation failed — server cert not trusted by the OS CA store, "
+				   "or hostname does not match cert CN/SAN");
+	} else if (context->use_tls) {
+		obs_log(LOG_ERROR,
+			"shout_open() failed with TLS enabled: %s. If the server does not speak TLS on "
+			"this port, uncheck 'Use TLS (HTTPS)' in Tools → Radio Output… and retry",
+			shout_get_error(shout));
+	} else {
+		obs_log(LOG_ERROR, "shout_open() failed: %s", shout_get_error(shout));
+	}
+}
+
+/*
+ * connect_complete — finish the start sequence after a successful shout_open:
+ * publish the handle, begin data capture, stand up the send thread, queue
+ * container startup bytes.  Mirrors the pre-async inline code that lived in
+ * radio_output_start.  Runs on the connect thread with job->mutex held and
+ * the context guaranteed alive.  Returns false with everything it created
+ * torn back down (the caller then signals OBS_OUTPUT_CONNECT_FAILED).
+ */
+static bool connect_complete(struct radio_output *context, shout_t *shout, const uint8_t *startup_bytes,
+			     size_t startup_len)
+{
+	context->shout = shout;
+	set_state(context, RADIO_STATE_CONNECTED);
+	context->reconnect_attempts = 0;
+	obs_log(LOG_INFO, "Connected to %s:%d%s", context->host, context->port, context->mount);
+
+	if (!obs_output_begin_data_capture(context->output, 0)) {
+		obs_log(LOG_ERROR, "obs_output_begin_data_capture() failed");
+		goto fail_after_open;
+	}
+
+	/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio;
+	 * radio_send_buf_init sets the data pointer last, so raw_audio's
+	 * send_buf.data "ready" gate only opens once the buffer is usable. */
+	context->send_running = true;
+	pthread_mutex_init(&context->send_mutex, NULL);
+	pthread_cond_init(&context->send_cond, NULL);
+	if (!radio_send_buf_init(&context->send_buf, SEND_BUF_CAPACITY)) {
+		obs_log(LOG_ERROR, "Failed to allocate send buffer");
+		context->send_running = false;
+		pthread_mutex_destroy(&context->send_mutex);
+		pthread_cond_destroy(&context->send_cond);
+		goto fail_after_capture;
+	}
+	if (pthread_create(&context->send_thread, NULL, encoder_send_thread, context) != 0) {
+		obs_log(LOG_ERROR, "Failed to create encoder send thread");
+		context->send_running = false;
+		radio_send_buf_free(&context->send_buf);
+		pthread_mutex_destroy(&context->send_mutex);
+		pthread_cond_destroy(&context->send_cond);
+		goto fail_after_capture;
+	}
+	obs_log(LOG_INFO, "Encoder send thread started (codec=%s)", context->encoder->name);
+
+	/* Queue container startup bytes (Ogg codecs: header pages) so the
+	 * send thread ships them before any audio.  MP3 has none. */
+	if (startup_bytes && startup_len > 0)
+		send_buf_push(context, startup_bytes, startup_len);
+
+	return true;
+
+fail_after_capture:
+	obs_output_end_data_capture(context->output);
+fail_after_open:
+	shout_close(context->shout);
+	shout_free(context->shout);
+	context->shout = NULL;
+	return false;
+}
+
+static void *connect_thread_fn(void *data)
+{
+	struct radio_connect_job *job = data;
+
+	const int err = shout_open(job->shout);
+
+	pthread_mutex_lock(&job->mutex);
+	if (job->canceled) {
+		/* Stop/destroy won the race; the context may already be freed.
+		 * Clean up only what the job owns. */
+		pthread_mutex_unlock(&job->mutex);
+		if (err == SHOUTERR_SUCCESS)
+			shout_handoff_cleanup(job->shout);
+		else
+			shout_free(job->shout);
+		bfree(job->startup_bytes);
+		connect_job_release(job);
+		return NULL;
+	}
+
+	/* Not canceled while holding job->mutex ⇒ teardown is blocked at its
+	 * cancel step, so the context stays alive for this whole block. */
+	struct radio_output *context = job->context;
+	bool ok = false;
+
+	if (err == SHOUTERR_SUCCESS) {
+		ok = connect_complete(context, job->shout, job->startup_bytes, job->startup_len);
+	} else {
+		log_shout_open_failure(context, job->shout, err);
+		shout_free(job->shout);
+	}
+
+	if (!ok) {
+		/* Mirror the synchronous failure path: drop the encoder under
+		 * encoder_mutex (a raw_audio callback could be in flight if
+		 * connect_complete failed after begin_data_capture), mark
+		 * ERROR so the dock shows red until the user acknowledges. */
+		pthread_mutex_lock(&context->encoder_mutex);
+		if (context->encoder) {
+			context->encoder->destroy(context);
+			context->encoder = NULL;
+		}
+		pthread_mutex_unlock(&context->encoder_mutex);
+		set_state(context, RADIO_STATE_ERROR);
+	}
+
+	/* Detach the job from the context.  The == check matters: teardown may
+	 * have already swapped the pointer out while waiting on job->mutex, in
+	 * which case the field ref is teardown's to drop, not ours. */
+	bool drop_field_ref = false;
+	pthread_mutex_lock(&context->state_mutex);
+	if (context->connect_job == job) {
+		context->connect_job = NULL;
+		drop_field_ref = true;
+	}
+	pthread_mutex_unlock(&context->state_mutex);
+
+	if (!ok)
+		obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
+
+	job->completed = true;
+	pthread_mutex_unlock(&job->mutex);
+
+	bfree(job->startup_bytes);
+	if (drop_field_ref)
+		connect_job_release(job);
+	connect_job_release(job);
+	return NULL;
+}
+
+/*
+ * connect_cancel — detach and cancel any in-flight async connect.  Never
+ * waits out a blocked shout_open: the job is flagged canceled and the
+ * connect thread cleans up after itself in the background.  If the thread
+ * is mid-completion, the brief job->mutex wait here lets it finish, after
+ * which the caller (teardown) tears down the now-started output normally.
+ */
+static void connect_cancel(struct radio_output *context)
+{
+	pthread_mutex_lock(&context->state_mutex);
+	struct radio_connect_job *job = context->connect_job;
+	context->connect_job = NULL;
+	pthread_mutex_unlock(&context->state_mutex);
+	if (!job)
+		return;
+
+	pthread_mutex_lock(&job->mutex);
+	job->canceled = true;
+	const bool was_pending = !job->completed;
+	pthread_mutex_unlock(&job->mutex);
+
+	if (was_pending)
+		obs_log(LOG_INFO, "connect attempt canceled; any in-flight handshake is reaped in the background");
+	connect_job_release(job);
 }
 #endif /* HAVE_LIBSHOUT */
 
@@ -697,8 +936,8 @@ static bool radio_output_start(void *data)
 	}
 
 	/* --- Configure libshout --- */
-	context->shout = shout_new();
-	if (!context->shout) {
+	shout_t *shout = shout_new();
+	if (!shout) {
 		obs_log(LOG_ERROR, "shout_new() failed (out of memory?)");
 		context->encoder->destroy(context);
 		context->encoder = NULL;
@@ -707,38 +946,38 @@ static bool radio_output_start(void *data)
 		return false;
 	}
 
-	shout_apply_settings(context, context->shout);
+	shout_apply_settings(context, shout);
 
-	/* --- Open connection --- */
+	/* --- Open connection (async, #61) ---
+	 * shout_open blocks and this callback runs on the Qt main thread, so
+	 * the open happens on a short-lived detached connect thread.  State is
+	 * CONNECTING before the thread spawns so the dock's next poll shows it
+	 * without a DISCONNECTED flicker; the thread finishes the start (or
+	 * signals CONNECT_FAILED) when shout_open returns.  context->shout
+	 * stays NULL until the thread publishes the opened handle. */
 	set_state(context, RADIO_STATE_CONNECTING);
 
-	int err = shout_open(context->shout);
-	if (err != SHOUTERR_SUCCESS) {
-		/* Surface TLS-specific failures with actionable text rather than
-		 * libshout's generic error string, which often reads as an
-		 * opaque socket/TLS mashup.  SHOUTERR_NOTLS fires only when the
-		 * server cleanly signals "no TLS" via an HTTP response; plain
-		 * servers that silently eat a TLS ClientHello yield
-		 * SHOUTERR_SOCKET after a ~14s TLS handshake timeout, so when
-		 * use_tls is on and we hit any non-TLS-specific failure, add
-		 * a TLS-may-be-the-cause hint so the user knows what to try. */
-		if (err == SHOUTERR_NOTLS) {
-			obs_log(LOG_ERROR, "TLS requested but the server does not support it; "
-					   "either disable TLS in Tools → Radio Output… or use a TLS-capable server");
-		} else if (err == SHOUTERR_TLSBADCERT) {
-			obs_log(LOG_ERROR,
-				"TLS certificate validation failed — server cert not trusted by the OS CA store, "
-				"or hostname does not match cert CN/SAN");
-		} else if (context->use_tls) {
-			obs_log(LOG_ERROR,
-				"shout_open() failed with TLS enabled: %s. If the server does not speak TLS on "
-				"this port, uncheck 'Use TLS (HTTPS)' in Tools → Radio Output… and retry",
-				shout_get_error(context->shout));
-		} else {
-			obs_log(LOG_ERROR, "shout_open() failed: %s", shout_get_error(context->shout));
-		}
-		shout_free(context->shout);
-		context->shout = NULL;
+	struct radio_connect_job *job = bzalloc(sizeof(*job));
+	job->context = context;
+	job->shout = shout;
+	job->startup_bytes = startup_bytes;
+	job->startup_len = startup_len;
+	pthread_mutex_init(&job->mutex, NULL);
+	job->refs = 2; /* connect thread + context->connect_job */
+
+	pthread_mutex_lock(&context->state_mutex);
+	context->connect_job = job;
+	pthread_mutex_unlock(&context->state_mutex);
+
+	pthread_t connect_tid;
+	if (pthread_create(&connect_tid, NULL, connect_thread_fn, job) != 0) {
+		obs_log(LOG_ERROR, "Failed to create connect thread");
+		pthread_mutex_lock(&context->state_mutex);
+		context->connect_job = NULL;
+		pthread_mutex_unlock(&context->state_mutex);
+		pthread_mutex_destroy(&job->mutex);
+		bfree(job);
+		shout_free(shout);
 		context->encoder->destroy(context);
 		context->encoder = NULL;
 		bfree(startup_bytes);
@@ -746,61 +985,10 @@ static bool radio_output_start(void *data)
 		obs_output_signal_stop(context->output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
 	}
+	pthread_detach(connect_tid);
 
-	set_state(context, RADIO_STATE_CONNECTED);
-	context->reconnect_attempts = 0;
-	obs_log(LOG_INFO, "Connected to %s:%d%s", context->host, context->port, context->mount);
-
-	if (!obs_output_begin_data_capture(context->output, 0)) {
-		obs_log(LOG_ERROR, "obs_output_begin_data_capture() failed");
-		bfree(startup_bytes);
-		goto start_fail_after_open;
-	}
-
-	/* --- Start shared send thread (all codecs) --- */
-	/* Initialize mutex/cond BEFORE making send_buf visible to raw_audio;
-	 * radio_send_buf_init sets the data pointer last, so raw_audio's
-	 * send_buf.data "ready" gate only opens once the buffer is usable. */
-	context->send_running = true;
-	pthread_mutex_init(&context->send_mutex, NULL);
-	pthread_cond_init(&context->send_cond, NULL);
-	if (!radio_send_buf_init(&context->send_buf, SEND_BUF_CAPACITY)) {
-		obs_log(LOG_ERROR, "Failed to allocate send buffer");
-		context->send_running = false;
-		pthread_mutex_destroy(&context->send_mutex);
-		pthread_cond_destroy(&context->send_cond);
-		bfree(startup_bytes);
-		goto start_fail_after_capture;
-	}
-	if (pthread_create(&context->send_thread, NULL, encoder_send_thread, context) != 0) {
-		obs_log(LOG_ERROR, "Failed to create encoder send thread");
-		context->send_running = false;
-		radio_send_buf_free(&context->send_buf);
-		pthread_mutex_destroy(&context->send_mutex);
-		pthread_cond_destroy(&context->send_cond);
-		bfree(startup_bytes);
-		goto start_fail_after_capture;
-	}
-	obs_log(LOG_INFO, "Encoder send thread started (codec=%s)", context->encoder->name);
-
-	/* Queue container startup bytes (Opus: OpusHead + OpusTags pages) so
-	 * the send thread ships them before any audio.  MP3 has none. */
-	if (startup_bytes && startup_len > 0)
-		send_buf_push(context, startup_bytes, startup_len);
-	bfree(startup_bytes);
-
+	obs_log(LOG_INFO, "Connecting to %s:%d%s ...", context->host, context->port, context->mount);
 	return true;
-
-start_fail_after_capture:
-	obs_output_end_data_capture(context->output);
-start_fail_after_open:
-	shout_close(context->shout);
-	shout_free(context->shout);
-	context->shout = NULL;
-	context->encoder->destroy(context);
-	context->encoder = NULL;
-	set_state(context, RADIO_STATE_ERROR);
-	return false;
 #endif
 }
 

--- a/src/radio-output.h
+++ b/src/radio-output.h
@@ -33,6 +33,10 @@ typedef enum {
 /* Forward-declared; the full struct lives in radio-encoder.h. */
 struct radio_encoder_ops;
 
+/* Forward-declared; the full struct lives in radio-output.c (async initial
+ * connect, #61). */
+struct radio_connect_job;
+
 struct radio_output {
 	obs_output_t *output; // back-pointer to OBS output object
 #ifdef HAVE_LIBSHOUT
@@ -137,6 +141,13 @@ struct radio_output {
 	pthread_cond_t send_cond;
 	pthread_t send_thread;
 	volatile bool send_running;
+
+	/* Async initial-connect job (#61).  Set in radio_output_start (under
+	 * state_mutex) when the connect thread spawns; cleared — also under
+	 * state_mutex — by whichever of {connect-thread completion, teardown's
+	 * cancel} gets there first.  See struct radio_connect_job in
+	 * radio-output.c for the lifetime/cancellation contract. */
+	struct radio_connect_job *connect_job;
 #endif
 };
 


### PR DESCRIPTION
**Summary**
- Fixes #61 — `shout_open` (DNS + TCP + libshout greeting + TLS handshake) no longer runs on the Qt main thread. Worst case observed during §E.2 testing was a **14.6 s UI beachball** with TLS on against a plain server; plain DNS/TCP timeouts beachballed for ~5–10 s.
- `radio_output_start` now does only the fast local work synchronously (encoder init, `shout_new`, `shout_apply_settings`), publishes `RADIO_STATE_CONNECTING`, and hands the configured-but-unopened handle to a short-lived **detached connect thread**. The thread runs `shout_open` and then completes the start (publish handle → `obs_output_begin_data_capture` → send thread → queue Ogg startup pages) or signals `OBS_OUTPUT_CONNECT_FAILED` — the same shape OBS core's rtmp-stream uses, and the same failure channel our reconnect give-up path already uses.
- **Stop never waits out a blocked handshake.** The connect attempt is tracked in a refcounted `radio_connect_job` (thread + context each hold a ref). Teardown atomically takes the context's job pointer (under `state_mutex`), flags it canceled (under `job->mutex`), and proceeds immediately; the blocked `shout_open` finishes in the background and hands an opened handle to the existing `shout_handoff_cleanup` detached-close path. A canceled thread never touches the context again, so destroy can't UAF. Conversely, while the thread holds `job->mutex` un-canceled, teardown is blocked at the flag-set — so the context is guaranteed alive for the entire completion, and a completion that wins the race is immediately followed by a normal full teardown.
- The TLS-aware `shout_open` error messaging (PR #60, `c091124`) moved verbatim into `log_shout_open_failure`; the post-open startup sequence moved verbatim into `connect_complete`. No behavior change in either.
- `radio.start` vendor verb: `ok=true` now means "start initiated" — callers poll `radio.status` for `connecting → connected|error` (comment updated; harness drivers already poll).

**Invariants preserved**
- PR #58's header-emit ordering: startup pages still enter the ring buffer before any audio (raw_audio's `send_buf.data` ready-gate opens only inside `connect_complete`, after the handle is published).
- PR #85's `encoder_mutex` discipline: the async failure path destroys the encoder under `encoder_mutex`, mirroring teardown.
- Error-state UX: async failures land in `RADIO_STATE_ERROR` + retained handle, exactly like the reconnect give-up path — dock shows red until Stop acknowledges.

**Test plan**
- [x] CI passes (clang-format, gersemi, build × 4 platforms, CodeQL, clang-tidy, Conventional Commits) — **all 11 checks green on `ce37a9e`**
- [x] Local: arm64 build green under `-Werror`; `ctest` **24/24 PASS**; pre-commit hooks pass

**Acceptance — automated, 2026-06-10, build `ce37a9e` loaded in OBS 31.1.1 ✅ ALL PASS**

Run via a new harness driver, `obs-ws-harness/async-connect-accept.mjs`. Measurement method: `radio.start` / `radio.applyConfig` marshal to the Qt main thread with `obs_queue_task(..., wait=true)`, so their round-trip latency is a *direct* measurement of main-thread availability — the old build could not answer them mid-`shout_open`.

| # | Test | Result | Measured evidence |
|---|------|--------|-------------------|
| A.1 | Happy path (MP3 → icecast-qa :8010) + async logs | ✅ PASS | `startRTT=2ms`; log `Connecting to` → `Connected to` → `Encoder send thread started (codec=mp3)`; ffprobe mp3/48000; `Disconnected` logged exactly 1× |
| A.2 | **The #61 repro** — TLS on vs plain :8010 | ✅ PASS | `radio.start` RTT **2 ms** (old build: ~14,600 ms); state `connecting` immediately; **max UI-thread probe RTT during the hang = 3 ms**; → `error` after 9.5 s with the PR #60 TLS hint |
| A.3 | Stop mid-handshake (DoD < 1 s) | ✅ PASS | state `connecting` at Stop; `stopRTT=0ms` → `disconnected`; `connect attempt canceled` logged; OBS alive + log clean after libshout's background timeout reaped (16 s wait) |
| A.4 | 3× rapid start/stop churn (job refcount stress) | ✅ PASS | start 1–2 ms / stop 0–3 ms each cycle; final `disconnected`; no crash |
| A.5 | Plain-TCP black hole (203.0.113.1) | ✅ PASS | `startRTT=1ms`, UI probe max 2 ms during TCP hang, cancel 1 ms, `connect attempt canceled` logged |
| A.6 | Fresh start from error state | ✅ PASS | `releasing prior errored output before retrying start` logged → `connected` |

**Regression — automated, same build ✅ ALL PASS**

- [x] `accept-phase2.mjs` full sweep: **16/16** (A.1a/b/c error-stop, C.1/C.2/C.4 MP3+Opus+reconnect w/ header re-emit, D.2/D.3 SHOUTcast, E.2/E.3 TLS failure paths, F.1 metadata, H all-three-codecs vtable cycle)
- [x] `tls-accept.mjs` vs the real Let's Encrypt rig (`radio.tech-noid.net:8443`): **E.1 ✅** (TLS connect + stream + https listener over the async path), **E.4 ✅** (reconnect under TLS, no plain fallback), **X.1 ✅** (TLS + Opus + reconnect, OpusTags re-emit). Note: the first run hit the *documented* rig artifact (HAProxy lingers a ghost source → `Login failed` on back-to-back connects); pod bounces between tests cleared it — not a plugin issue (recorded in SESSION-LOG 2026-06-09).

**Not re-run (covered by prior authority)**
- Auto-start-with-streaming (needs an RTMP sink on the profile): PR #25's 5/5 acceptance incl. failure isolation remains authoritative; the failure now arrives via the same `signal_stop` channel exercised in A.2/A.6.