### PR TITLE
fix(stop): hand teardown shout_close to the detached cleanup thread

### DIFF
--- a/src/radio-output.c
+++ b/src/radio-output.c
@@ -109,6 +109,7 @@ static void *radio_output_create(obs_data_t *settings, obs_output_t *output)
 
 #ifdef HAVE_LIBSHOUT
 static void connect_cancel(struct radio_output *context);
+static void shout_handoff_cleanup(shout_t *handle);
 #endif
 
 /*
@@ -185,9 +186,15 @@ static void radio_output_teardown(struct radio_output *context)
 		if (flush_ret != SHOUTERR_SUCCESS)
 			obs_log(LOG_WARNING, "shout_send() flush failed: %s", shout_get_error(context->shout));
 	}
+	/* Detached close (#80): libshout's graceful protocol-close writes a
+	 * goodbye message, and against a half-dead peer (no RST yet) that send
+	 * blocks until the kernel TCP timeout (~60 s on macOS).  The send-thread
+	 * failure path has used shout_handoff_cleanup since PR #21; the teardown
+	 * path kept an inline close because it usually runs against a healthy
+	 * connection — but "usually" beachballs OBS shutdown the day the peer
+	 * died quietly.  Hand the close to the detached thread unconditionally. */
 	if (context->shout) {
-		shout_close(context->shout);
-		shout_free(context->shout);
+		shout_handoff_cleanup(context->shout);
 		context->shout = NULL;
 	}
 #endif /* HAVE_LIBSHOUT */


### PR DESCRIPTION
**Summary**
- Fixes #80 — `radio_output_teardown` no longer calls `shout_close` synchronously on the OBS main thread. The graceful protocol-close writes a goodbye message; against a half-dead peer (no RST yet — NAT table expired, listener process died, half-open send buffer) that `send()` blocks until the kernel TCP timeout (~60 s on macOS), beachballing Stop and OBS shutdown.
- The send-thread failure path has used `shout_handoff_cleanup` (detached close thread) since PR #21; this swaps the teardown call site onto the same helper. One-line call-site change + a forward declaration.
- Flush ordering unchanged: trailing encoder bytes still go out via `shout_send` before the handle is handed off.

**Test plan**
- [x] CI passes — CodeQL, clang-tidy, Ubuntu, Windows, formats, commits all green; macOS build green local under `-Werror` (CI macOS pending at time of writing, gate before merge)
- [x] Local: arm64 build green under `-Werror`; `ctest` **24/24 PASS**; pre-commit hooks pass

**Acceptance — automated, 2026-06-10, build `32de141` loaded in OBS 31.1.1 ✅ ALL PASS**

| # | Test | Result | Measured evidence |
|---|------|--------|-------------------|
| 1 | Happy-path stop timing (MP3 → icecast-qa :8010, ~3 s stream, `radio.stop`) | ✅ PASS | stop RTT **1 ms** → `disconnected`; mount released; single `Disconnected from` |
| 2 | **The #80 stress case** — `docker kill icecast-qa` (no FIN/RST) + immediate `radio.stop` | ✅ PASS | stop RTT **1 ms** (pre-change risk: up to ~60 s TCP-timeout hang) → `disconnected`; OBS alive + responsive after the kernel-reap window |
| 3 | Regression: `async-connect-accept.mjs` | ✅ **6/6** | async-connect suite from PR #106 all green on this build |
| 4 | Regression: `accept-phase2.mjs` | ✅ **16/16** | full Phase 2 sweep green on this build |