### PR TITLE
chore: bump version to 0.2.0 ahead of beta release

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "obs-radio-output",
     "displayName": "Radio Output",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "author": "Aaron Cupp",
     "website": "https://github.com/tech-noid-systems/obs-radio-output",
     "email": "mrcupp@mrcupp.com"


### PR DESCRIPTION
**Summary**
- Bumps `buildspec.json` plugin version `0.1.0` → `0.2.0` so the source version matches the upcoming `0.2.0-beta1` tag.
- Everything since `0.1.0-alpha1` is well past an alpha increment: native UI + dock, TLS, Opus + Vorbis codecs, in-band Ogg metadata, listener count, BUTT codec parity, obs-websocket vendor API, async connect, detached teardown, Developer ID signing. The `0.2.0` + `beta` framing honestly signals macOS + Linux ready / Windows pending.
- Tag-time version override already handles the build, but bumping the source keeps it honest.

**Test plan**
- [ ] CI green (no behavior change — version string only)