### PR TITLE
feat(windows): enable MP3/Opus/Vorbis codecs (#37)

### DIFF
--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -56,7 +56,16 @@ function Build {
     Log-Group "Building vendored libshout..."
     Invoke-External pwsh -NoProfile -File "${ProjectRoot}/deps/libshout-win/build.ps1" -InstallPrefix $LibShoutPrefix
 
-    $CmakeArgs = @('--preset', "windows-ci-${Target}", "-DLibShout_ROOT=${LibShoutPrefix}")
+    # One self-contained prefix carries libshout + the codec libs/headers; point
+    # every Find<Lib>_ROOT at it so the plugin's MP3/Opus/Vorbis encoders light up.
+    $CmakeArgs = @(
+        '--preset', "windows-ci-${Target}"
+        "-DLibShout_ROOT=${LibShoutPrefix}"
+        "-DLibLame_ROOT=${LibShoutPrefix}"
+        "-DLibOpus_ROOT=${LibShoutPrefix}"
+        "-DLibOgg_ROOT=${LibShoutPrefix}"
+        "-DLibVorbis_ROOT=${LibShoutPrefix}"
+    )
     $CmakeBuildArgs = @('--build')
     $CmakeInstallArgs = @()
 

--- a/cmake/FindLibLame.cmake
+++ b/cmake/FindLibLame.cmake
@@ -21,7 +21,8 @@ endif()
 
 find_library(
   LibLame_LIBRARY
-  NAMES mp3lame libmp3lame
+  # libmp3lame-static: vcpkg's name for the static LAME on Windows (x64-windows-static-md).
+  NAMES mp3lame libmp3lame libmp3lame-static
   PATHS
     /usr/lib
     /usr/local/lib

--- a/cmake/FindLibLame.cmake
+++ b/cmake/FindLibLame.cmake
@@ -32,6 +32,18 @@ find_library(
     $ENV{LIBLAME_LIB}
 )
 
+# vcpkg splits LAME's bundled mpglib decoder into a separate libmpghip-static;
+# libmp3lame-static references it (InitMP3 etc.), so it must be linked alongside.
+# Only present in the vcpkg static build; absent (and unneeded) elsewhere.
+find_library(
+  LibLame_HIP_LIBRARY
+  NAMES mpghip libmpghip-static
+  PATHS
+    ${LibLame_ROOT}/lib
+    $ENV{LIBLAME_ROOT}/lib
+    $ENV{LIBLAME_LIB}
+)
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibLame REQUIRED_VARS LibLame_LIBRARY LibLame_INCLUDE_DIR)
 
@@ -43,5 +55,8 @@ if(LibLame_FOUND AND NOT TARGET LibLame::LibLame)
       IMPORTED_LOCATION "${LibLame_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${LibLame_INCLUDE_DIR}"
   )
+  if(LibLame_HIP_LIBRARY)
+    set_target_properties(LibLame::LibLame PROPERTIES INTERFACE_LINK_LIBRARIES "${LibLame_HIP_LIBRARY}")
+  endif()
 endif()
 # gersemi: on

--- a/deps/libshout-win/build.ps1
+++ b/deps/libshout-win/build.ps1
@@ -97,12 +97,21 @@ Write-Host "==> shout.lib installed: $Lib ($kb KB)"
 # bundling them lets the plugin link everything from one prefix WITHOUT pulling
 # the vcpkg toolchain into the plugin build (which fights the OBS template's
 # obs-deps discovery).  See the WIN32 branch in the top-level CMakeLists.txt.
-$VcpkgLib = Join-Path $BuildDir 'vcpkg_installed/x64-windows-static-md/lib'
+$VcpkgRootDir = Join-Path $BuildDir 'vcpkg_installed/x64-windows-static-md'
+$VcpkgLib = Join-Path $VcpkgRootDir 'lib'
 if ( -not (Test-Path $VcpkgLib) ) { throw "vcpkg install libs not found at $VcpkgLib" }
 $destLib = Join-Path $InstallPrefix 'lib'
 Copy-Item "$VcpkgLib/*.lib" $destLib -Force
 Write-Host "==> bundled vcpkg dep libs into ${destLib}:"
 Get-ChildItem "$destLib/*.lib" | ForEach-Object { Write-Host "     $($_.Name)" }
+
+# Bundle the dep headers too (lame/, opus/, ogg/, vorbis/, openssl/) so the
+# plugin's encoders can include them off the same prefix.  The plugin's
+# Find{LibLame,LibOpus,LibOgg,LibVorbis} modules look under <prefix>/include +
+# <prefix>/lib when handed <Lib>_ROOT (see Build-Windows.ps1).
+$destInc = Join-Path $InstallPrefix 'include'
+Copy-Item "$VcpkgRootDir/include/*" $destInc -Recurse -Force
+Write-Host "==> bundled vcpkg dep headers into ${destInc}"
 
 # TLS sanity check: shout_tls_new only exists when HAVE_OPENSSL compiled in
 # (tls.c wraps its body in #ifdef HAVE_OPENSSL).  Analogous to the macOS build's

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "obs-radio-output",
   "version-string": "0.2.0",
-  "description": "Windows (MSVC) build dependencies. Consumed only when the build is configured with the vcpkg toolchain (Windows CI); inert on macOS/Linux, which source these libraries from obs-deps / apt / from-source builds. ogg+vorbis+openssl+pthreads back the vendored libshout build (deps/libshout-win); codec libraries are added alongside their encoders.",
+  "description": "Windows (MSVC) build dependencies, installed by the vendored libshout build (deps/libshout-win) and bundled into its prefix; inert on macOS/Linux, which source these from obs-deps / apt / from-source builds. ogg+vorbis+openssl+pthreads back libshout; mp3lame+opus (+vorbis) back the plugin's MP3/Opus/Vorbis encoders.",
   "dependencies": [
     "libogg",
     "libvorbis",
+    "mp3lame",
+    "opus",
     "openssl",
     "pthreads"
   ]


### PR DESCRIPTION
**Summary**

Builds on #112 — un-stubs the **MP3 / Opus / Vorbis encoders on Windows**, so the plugin can now encode and stream there (not just link libshout).

- Adds **`mp3lame`** + **`opus`** to the root `vcpkg.json` (ogg/vorbis were already there for libshout).
- `deps/libshout-win/build.ps1` now bundles the vcpkg **headers** (and libs) into the libshout prefix — one self-contained prefix holding `shout.lib` + all codec libs/headers.
- `Build-Windows.ps1` points `LibLame_ROOT` / `LibOpus_ROOT` / `LibOgg_ROOT` / `LibVorbis_ROOT` at that prefix; the existing `find_package(... QUIET)` codec blocks then resolve and define `HAVE_LAME`/`HAVE_OPUS`/`HAVE_VORBIS` — no plugin CMake changes.
- `FindLibLame` learned vcpkg's split static naming: **`libmp3lame-static`** + its companion **`libmpghip-static`** (LAME's bundled mpglib decoder, referenced by `libmp3lame-static`).

No vcpkg toolchain in the plugin build (same decoupled approach as #112). macOS/Linux untouched.

**Test plan — ✅ PASS**

- [x] **Windows build** 🪟 — MP3/Opus/Vorbis encoder sources compile under MSVC `cl` with their `HAVE_*` bodies active, and the plugin links lame(+hip)/opus/vorbis/vorbisenc + libshout. **PASS** ([run](https://github.com/Tech-Noid-Systems/obs-radio-output/actions/runs/27386818974/job/80935561023), 9m7s). First time these encoders compile on MSVC — no GCC-isms surfaced.
- [x] No `... not found — ... not available on Windows` warnings in the configure log → all three codecs resolved and `HAVE_*` defined. **PASS**
- [x] **macOS** 🍏 (9m10s) + **Ubuntu** 🐧 (1m28s) builds + unit tests green. **PASS**
- [x] format / CodeQL / clang-tidy / Conventional Commits green (11/11 checks). **PASS**

**Remaining for #37:** end-to-end Windows streaming (MP3/Opus/Vorbis/TLS/reconnect → live Icecast from a Windows OBS) — needs a Windows box; no headless Windows OBS in CI (#94). Windows now **builds the complete plugin** (libshout + all codecs + TLS); that acceptance pass is the last gate before #37 fully closes.
