### PR TITLE
docs(windows): refresh build instructions for the from-source libshout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ cmake --install build_linux_x86_64 --config RelWithDebInfo \
 
 ### Windows
 
-**Prerequisites:** Windows 10/11 x64 with Visual Studio 2022 (`Desktop development with C++`
-workload) and `winget`. MSYS2 and libshout will be installed automatically by the setup script.
+**Prerequisites:** Windows 10/11 x64 with Visual Studio 2022 — the `Desktop development with C++`
+workload **and** the `C++ Clang tools for Windows` component (libshout is built with clang-cl) —
+plus `winget`. libshout and its codec dependencies are built from source automatically by the
+setup script (clang-cl + the vcpkg bundled with Visual Studio); no MSYS2 needed.
 
 ```powershell
 git clone https://github.com/tech-noid-systems/obs-radio-output.git
@@ -154,9 +156,10 @@ cmake --install build_x64 --config RelWithDebInfo `
       --prefix "$env:APPDATA\obs-studio\plugins\obs-radio-output"
 ```
 
-> **Note:** Streaming to Icecast/SHOUTcast is not yet functional on Windows. The plugin will
-> load in OBS but the streaming output requires MSVC-compatible libshout binaries — tracked as
-> [#37](https://github.com/tech-noid-systems/obs-radio-output/issues/37), contributions welcome.
+> **Note:** Windows builds the **full streaming stack** — libshout (with TLS) and the MP3, Opus,
+> and Vorbis encoders. End-to-end streaming to Icecast/SHOUTcast has **not yet been verified** on a
+> Windows test machine; if you run a stream from Windows, please report results on
+> [#37](https://github.com/tech-noid-systems/obs-radio-output/issues/37).
 
 ## Usage
 

--- a/scripts/Setup-Dev-Windows.ps1
+++ b/scripts/Setup-Dev-Windows.ps1
@@ -1,10 +1,12 @@
 # Setup-Dev-Windows.ps1 — Set up the obs-radio-output local development environment on Windows.
 #
 # What this script does:
-#   1. Checks for Visual Studio 2022 (Build Tools or IDE)
-#   2. Checks for / installs MSYS2
-#   3. Installs libshout and pkg-config via MSYS2 MinGW64
-#   4. Runs CMake configure using the 'windows-x64' preset
+#   1. Checks for Visual Studio 2022 with the C++ and clang-cl (ClangCL) components
+#   2. Checks for / installs CMake
+#   3. Resolves a vcpkg root (uses the copy bundled with Visual Studio if needed)
+#   4. Builds libshout from source as an MSVC static lib + bundles its codec deps
+#      (deps/libshout-win/build.ps1 — the same step CI runs)
+#   5. Runs CMake configure pointed at that prefix
 #
 # Prerequisites:
 #   - Windows 10/11 x64
@@ -18,23 +20,23 @@
 #   cmake --install build_x64 --config RelWithDebInfo `
 #         --prefix "$env:APPDATA\obs-studio\plugins\obs-radio-output"
 #
-# NOTE: Windows streaming support (libshout linking against MSVC) is not yet
-# fully implemented. The plugin will build and load in OBS but streaming will
-# not function until MSVC-compatible libshout binaries are available.
+# NOTE: Windows now builds the full streaming stack — libshout (with TLS) plus the
+# MP3 / Opus / Vorbis encoders. End-to-end streaming has not yet been verified on a
+# Windows test machine; see https://github.com/tech-noid-systems/obs-radio-output/issues/37.
 
 #Requires -Version 5.1
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
-$RepoRoot   = Split-Path -Parent $ScriptDir
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent $ScriptDir
 
-function Write-Step  { param($msg) Write-Host "▶ $msg" -ForegroundColor Cyan }
-function Write-Ok    { param($msg) Write-Host "✔ $msg" -ForegroundColor Green }
-function Write-Warn  { param($msg) Write-Host "⚠ $msg" -ForegroundColor Yellow }
-function Write-Fail  { param($msg) Write-Host "✖ $msg" -ForegroundColor Red; exit 1 }
+function Write-Step { param($msg) Write-Host "▶ $msg" -ForegroundColor Cyan }
+function Write-Ok { param($msg) Write-Host "✔ $msg" -ForegroundColor Green }
+function Write-Warn { param($msg) Write-Host "⚠ $msg" -ForegroundColor Yellow }
+function Write-Fail { param($msg) Write-Host "✖ $msg" -ForegroundColor Red; exit 1 }
 
-# ── 1. Check Visual Studio 2022 ───────────────────────────────────────────────
+# ── 1. Check Visual Studio 2022 (+ clang-cl) ─────────────────────────────────
 Write-Step "Checking for Visual Studio 2022..."
 
 $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -42,8 +44,8 @@ if (-not (Test-Path $vsWhere)) {
   Write-Warn "vswhere.exe not found. Visual Studio 2022 may not be installed."
   Write-Host ""
   Write-Host "Install Visual Studio 2022 (Community or Build Tools) with the" -ForegroundColor Yellow
-  Write-Host "'Desktop development with C++' workload from:" -ForegroundColor Yellow
-  Write-Host "  https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
+  Write-Host "'Desktop development with C++' workload AND the 'C++ Clang tools for Windows'" -ForegroundColor Yellow
+  Write-Host "component, from: https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
   Write-Host ""
   Write-Fail "Visual Studio 2022 is required. Install it and re-run this script."
 }
@@ -54,6 +56,20 @@ if (-not $vsInstall) {
 }
 Write-Ok "Visual Studio 2022 found: $vsInstall"
 
+# libshout is built with clang-cl (it uses the GCC void-pointer-arithmetic
+# extension that the MSVC cl compiler rejects).  Warn — don't fail — if the
+# ClangCL toolset component isn't detected; detection isn't always reliable.
+$clangVs = & $vsWhere -latest -version "[17,18)" `
+  -requires Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset `
+  -property installationPath 2>$null
+if (-not $clangVs) {
+  Write-Warn "The 'C++ Clang tools for Windows' (ClangCL) component was not detected."
+  Write-Warn "libshout needs clang-cl. In the VS Installer, Modify -> Individual components ->"
+  Write-Warn "add 'C++ Clang Compiler for Windows' and 'MSBuild support for LLVM (clang-cl) toolset'."
+} else {
+  Write-Ok "ClangCL toolset present."
+}
+
 # ── 2. Check / install CMake ──────────────────────────────────────────────────
 Write-Step "Checking for CMake..."
 if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
@@ -62,7 +78,7 @@ if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
     winget install --id Kitware.CMake --silent --accept-package-agreements --accept-source-agreements
     # Refresh PATH
     $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
-                [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    [System.Environment]::GetEnvironmentVariable("PATH", "User")
   } else {
     Write-Fail "winget not available. Install CMake manually from https://cmake.org/download/"
   }
@@ -70,34 +86,36 @@ if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
 $cmakeVersion = (cmake --version | Select-Object -First 1)
 Write-Ok "CMake found: $cmakeVersion"
 
-# ── 3. Check / install MSYS2 ─────────────────────────────────────────────────
-Write-Step "Checking for MSYS2..."
-$msys2Root = "C:\msys64"
-if (-not (Test-Path "$msys2Root\usr\bin\bash.exe")) {
-  Write-Warn "MSYS2 not found at $msys2Root. Attempting to install via winget..."
-  if (Get-Command winget -ErrorAction SilentlyContinue) {
-    winget install --id MSYS2.MSYS2 --silent --accept-package-agreements --accept-source-agreements
-    if (-not (Test-Path "$msys2Root\usr\bin\bash.exe")) {
-      Write-Fail "MSYS2 install did not produce expected files. Install manually from https://www.msys2.org/"
-    }
+# ── 3. Resolve a vcpkg root ──────────────────────────────────────────────────
+# The libshout build pulls ogg/vorbis/openssl/pthreads/mp3lame/opus from vcpkg.
+# Prefer an existing VCPKG_INSTALLATION_ROOT; otherwise fall back to the copy
+# bundled with Visual Studio 2022 (VC\vcpkg).
+Write-Step "Resolving vcpkg..."
+if (-not $env:VCPKG_INSTALLATION_ROOT) {
+  $vsVcpkg = Join-Path $vsInstall 'VC\vcpkg'
+  if (Test-Path (Join-Path $vsVcpkg 'scripts\buildsystems\vcpkg.cmake')) {
+    $env:VCPKG_INSTALLATION_ROOT = $vsVcpkg
   } else {
-    Write-Fail "winget not available. Install MSYS2 manually from https://www.msys2.org/ to $msys2Root"
+    Write-Fail "vcpkg not found. Set VCPKG_INSTALLATION_ROOT, or install vcpkg (https://vcpkg.io)."
   }
 }
-Write-Ok "MSYS2 found at $msys2Root"
+Write-Ok "Using vcpkg at $($env:VCPKG_INSTALLATION_ROOT)"
 
-# ── 4. Install libshout via MSYS2 MinGW64 ────────────────────────────────────
-Write-Step "Installing libshout and pkg-config via MSYS2 MinGW64..."
-$bash = "$msys2Root\usr\bin\bash.exe"
-& $bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-libshout mingw-w64-x86_64-pkg-config" 2>&1
-Write-Ok "MSYS2 MinGW64 libshout installed"
+# ── 4. Build libshout (+ bundled codec deps) from source ─────────────────────
+Write-Step "Building libshout from source (clang-cl + vcpkg)... this takes a few minutes."
+$LibShoutPrefix = Join-Path $RepoRoot 'build-deps\libshout'
+& "$RepoRoot\deps\libshout-win\build.ps1" -InstallPrefix $LibShoutPrefix
+Write-Ok "libshout built and installed to $LibShoutPrefix"
 
 # ── 5. CMake configure ────────────────────────────────────────────────────────
 Write-Step "Running CMake configure (preset: windows-x64)..."
 Set-Location $RepoRoot
 cmake --preset windows-x64 `
-  -DLibShout_ROOT="C:/msys64/mingw64" `
-  -DCMAKE_PREFIX_PATH="C:/msys64/mingw64"
+  -DLibShout_ROOT="$LibShoutPrefix" `
+  -DLibLame_ROOT="$LibShoutPrefix" `
+  -DLibOpus_ROOT="$LibShoutPrefix" `
+  -DLibOgg_ROOT="$LibShoutPrefix" `
+  -DLibVorbis_ROOT="$LibShoutPrefix"
 Write-Ok "CMake configure complete — build directory: build_x64\"
 
 # ── Done ──────────────────────────────────────────────────────────────────────
@@ -111,9 +129,8 @@ Write-Host "Install to OBS:" -ForegroundColor White
 Write-Host "  cmake --install build_x64 --config RelWithDebInfo ``" -ForegroundColor Cyan
 Write-Host "        --prefix `"$env:APPDATA\obs-studio\plugins\obs-radio-output`"" -ForegroundColor Cyan
 Write-Host ""
-Write-Host "Then launch OBS and check Help → Log Files → Current Log for:" -ForegroundColor White
+Write-Host "Then launch OBS and check Help -> Log Files -> Current Log for:" -ForegroundColor White
 Write-Host "  [obs-radio-output] plugin loaded successfully" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "NOTE: Streaming to Icecast/SHOUTcast is not yet functional on Windows." -ForegroundColor Yellow
-Write-Host "The plugin will load in OBS but the streaming output requires MSVC-compatible" -ForegroundColor Yellow
-Write-Host "libshout binaries (tracked as a known issue)." -ForegroundColor Yellow
+Write-Host "NOTE: Windows builds the full streaming stack (libshout + MP3/Opus/Vorbis + TLS)," -ForegroundColor Yellow
+Write-Host "but end-to-end streaming has not yet been verified on Windows — see issue #37." -ForegroundColor Yellow


### PR DESCRIPTION
**Summary**

Refreshes the Windows build docs to match the new from-source libshout flow landed in #112 / #113. The old instructions described the abandoned MSYS2/MinGW path and said streaming "is not yet functional on Windows" — both now wrong.

- **`README.md`** Windows section:
  - Prerequisites now call out the **`C++ Clang tools for Windows`** component (libshout builds with clang-cl); drop the "MSYS2 + libshout installed automatically" line — libshout + codec deps are built from source via clang-cl + the vcpkg bundled with VS2022.
  - The streaming note is reframed honestly: Windows builds the **full streaming stack** (libshout + TLS + MP3/Opus/Vorbis); end-to-end streaming is **not yet verified** on a Windows machine — testers welcome on #37.
- **`scripts/Setup-Dev-Windows.ps1`** rewritten to the real flow: check VS2022 + ClangCL, resolve a vcpkg root (falls back to the VS-bundled `VC\vcpkg`), build libshout via `deps/libshout-win/build.ps1`, then configure with the libshout + codec `*_ROOT` hints. Removes the MSYS2 install + MinGW `LibShout_ROOT` steps.

Deliberately **not** claiming "Windows streaming works" or cutting a release — that waits on a live end-to-end run on a Windows box (no headless Windows OBS in CI, #94).

**Test plan**

- [ ] CI green (docs/script-only; no build inputs changed — macOS/Ubuntu/Windows builds + format/CodeQL/clang-tidy unaffected).
- [ ] Prose review: README Windows section reads correctly; no remaining "not yet functional" / "MSVC-compatible libshout binaries" / MSYS2 references (`grep` confirms only the new wording remains).
- _Manual (needs a Windows box, optional):_ `.\scripts\Setup-Dev-Windows.ps1` on a clean VS2022 + ClangCL install resolves vcpkg, builds libshout, and configures `build_x64`.
